### PR TITLE
Recognize many standard library types (fixes #17)

### DIFF
--- a/src/Language/C/Inline/Context.hs
+++ b/src/Language/C/Inline/Context.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -47,10 +48,12 @@ import           Control.Monad.Trans.Maybe (MaybeT, runMaybeT)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as BS
 import qualified Data.Map as Map
+import           Data.Int (Int8, Int16, Int32, Int64)
 import           Data.Monoid ((<>))
 import           Data.Typeable (Typeable)
 import qualified Data.Vector.Storable as V
 import qualified Data.Vector.Storable.Mutable as VM
+import           Data.Word (Word8, Word16, Word32, Word64)
 import           Foreign.C.Types
 import           Foreign.Ptr (Ptr, FunPtr)
 import           Foreign.Storable (Storable)
@@ -167,6 +170,10 @@ baseCtx = mempty
 baseTypesTable :: Map.Map C.TypeSpecifier TH.TypeQ
 baseTypesTable = Map.fromList
   [ (C.Void, [t| () |])
+  -- Types from Foreign.C.Types in the order in which they are presented there,
+  -- along with its documentation's section headers.
+  --
+  -- Integral types
   , (C.Char Nothing, [t| CChar |])
   , (C.Char (Just C.Signed), [t| CSChar |])
   , (C.Char (Just C.Unsigned), [t| CUChar |])
@@ -176,10 +183,39 @@ baseTypesTable = Map.fromList
   , (C.Int C.Unsigned, [t| CUInt |])
   , (C.Long C.Signed, [t| CLong |])
   , (C.Long C.Unsigned, [t| CULong |])
+  , (C.TypeName "ptrdiff_t", [t| CPtrdiff |])
+  , (C.TypeName "size_t", [t| CSize |])
+  , (C.TypeName "wchar_t", [t| CWchar |])
+  , (C.TypeName "sig_atomic_t", [t| CSigAtomic |])
   , (C.LLong C.Signed, [t| CLLong |])
   , (C.LLong C.Unsigned, [t| CULLong |])
+  , (C.TypeName "intptr_t", [t| CIntPtr |])
+  , (C.TypeName "uintptr_t", [t| CUIntPtr |])
+  , (C.TypeName "intmax_t", [t| CIntMax |])
+  , (C.TypeName "uintmax_t", [t| CUIntMax |])
+  -- Numeric types
+  , (C.TypeName "clock_t", [t| CClock |])
+  , (C.TypeName "time_t", [t| CTime |])
+  , (C.TypeName "useconds_t", [t| CUSeconds |])
+  , (C.TypeName "suseconds_t", [t| CSUSeconds |])
+  -- Floating types
   , (C.Float, [t| CFloat |])
   , (C.Double, [t| CDouble |])
+  -- Other types
+  , (C.TypeName "FILE", [t| CFile |])
+  , (C.TypeName "fpos_t", [t| CFpos |])
+  , (C.TypeName "jmp_buf", [t| CJmpBuf |])
+  -- Types from stdint.h that can be statically mapped to their Haskell
+  -- equivalents. Excludes int_fast*_t and int_least*_t and the corresponding
+  -- unsigned types, since their sizes are platform-specific.
+  , (C.TypeName "int8_t", [t| Int8 |])
+  , (C.TypeName "int16_t", [t| Int16 |])
+  , (C.TypeName "int32_t", [t| Int32 |])
+  , (C.TypeName "int64_t", [t| Int64 |])
+  , (C.TypeName "uint8_t", [t| Word8 |])
+  , (C.TypeName "uint16_t", [t| Word16 |])
+  , (C.TypeName "uint32_t", [t| Word32 |])
+  , (C.TypeName "uint64_t", [t| Word64 |])
   ]
 
 -- | An alias for 'Ptr'.

--- a/test/Language/C/Inline/ContextSpec.hs
+++ b/test/Language/C/Inline/ContextSpec.hs
@@ -9,6 +9,7 @@
 module Language.C.Inline.ContextSpec (spec) where
 
 import           Control.Monad.Trans.Class (lift)
+import           Data.Word
 import qualified Test.Hspec as Hspec
 import           Text.Parser.Char
 import           Text.Parser.Combinators
@@ -31,6 +32,12 @@ spec = do
     shouldBeType (cty "char") [t| CChar |]
   Hspec.it "converts void" $ do
     shouldBeType (cty "void") [t| () |]
+  Hspec.it "converts standard library types (1)" $ do
+    shouldBeType (cty "FILE") [t| CFile |]
+  Hspec.it "converts standard library types (2)" $ do
+    shouldBeType (cty "uint16_t") [t| Word16 |]
+  Hspec.it "converts standard library types (3)" $ do
+    shouldBeType (cty "jmp_buf") [t| CJmpBuf |]
   Hspec.it "converts single ptr type" $ do
     shouldBeType (cty "long*") [t| Ptr CLong |]
   Hspec.it "converts double ptr type" $ do

--- a/test/Language/C/Inline/ContextSpec.hs
+++ b/test/Language/C/Inline/ContextSpec.hs
@@ -72,7 +72,7 @@ spec = do
       [t| CArray (Ptr (FunPtr (CInt -> IO (Ptr (CArray (Ptr CChar)))))) |]
   where
     goodConvert cTy = do
-      mbHsTy <- TH.runQ $ convertType IO (ctxTypesTable baseCtx) cTy
+      mbHsTy <- TH.runQ $ convertType IO baseTypes cTy
       case mbHsTy of
         Nothing   -> error $ "Could not convert type (goodConvert)"
         Just hsTy -> return hsTy
@@ -83,8 +83,10 @@ spec = do
       x `Hspec.shouldBe` y
 
     assertParse p s =
-      case C.runCParser (const False) "spec" s (lift spaces *> p <* lift eof) of
+      case C.runCParser (isTypeName baseTypes) "spec" s (lift spaces *> p <* lift eof) of
         Left err -> error $ "Parse error (assertParse): " ++ show err
         Right x -> x
 
     cty s = C.parameterDeclarationType $ assertParse C.parseParameterDeclaration s
+
+    baseTypes = ctxTypesTable baseCtx

--- a/test/tests.hs
+++ b/test/tests.hs
@@ -22,6 +22,8 @@ import           Dummy
 C.context (C.baseCtx <> C.funCtx <> C.vecCtx <> C.bsCtx)
 
 C.include "<math.h>"
+C.include "<stddef.h>"
+C.include "<stdint.h>"
 C.include "<stdio.h>"
 
 C.verbatim [r|
@@ -81,6 +83,21 @@ main = Hspec.hspec $ do
       z `Hspec.shouldBe` x + y + 7
     Hspec.it "void exp" $ do
       [C.exp| void { printf("Hello\n") } |]
+    Hspec.it "Foreign.C.Types library types" $ do
+      let x = 1
+      pd <- [C.block| ptrdiff_t { char a[2]; return &a[1] - &a[0] + $(ptrdiff_t x); } |]
+      pd `Hspec.shouldBe` 2
+      sz <- [C.exp| size_t { sizeof (char) } |]
+      sz `Hspec.shouldBe` 1
+      um <- [C.exp| uintmax_t { UINTMAX_MAX } |]
+      um `Hspec.shouldBe` maxBound
+    Hspec.it "stdint.h types" $ do
+      let x = 2
+      i16 <- [C.exp| int16_t { 1 + $(int16_t x) } |]
+      i16 `Hspec.shouldBe` 3
+      let y = 9
+      u32 <- [C.exp| uint32_t { $(uint32_t y) * 7 } |]
+      u32 `Hspec.shouldBe` 63
     Hspec.it "function pointer argument" $ do
       let ackermann m n
             | m == 0 = n + 1


### PR DESCRIPTION
Also includes a change that makes the tests recognize types in the "normal" fashion, so that use of these types can be tested. (I don't know if there was an important reason for not using `isTypeName` there.)