### PR TITLE
Fix signature in call to ackermannIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ main = do
   let x = 3
   let y = 4
   z <- [C.exp| long{
-      $fun:(int (*ackermannIO)(int, int))($(long x), $(long y))
+      $fun:(long (*ackermannIO)(long, long))($(long x), $(long y))
     } |]
   print z
 ```


### PR DESCRIPTION
According to the definition of `ackermann`, the types for `ackermannIO` need to be `long` instead of `int` (fixes compile-time error).