### PR TITLE
Example usage specifies an incorrect GCC flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ executable foo
   -- These flags will be passed to the C compiler
   cc-options:          -Wall -O2
   -- Libraries to link the code with.
-  extra-libraries:     -lm
+  extra-libraries:     m
   ...
 ```
 


### PR DESCRIPTION
The Math library should be given as "m", not "-lm".