### PR TITLE
Fix typo in "How it works" docs

### DIFF
--- a/src/Language/C/Inline.hs
+++ b/src/Language/C/Inline.hs
@@ -228,6 +228,7 @@ import           Language.C.Inline.FunPtr
 --     }
 --   } |]
 --   'return' vec
+-- @
 --
 -- == How it works
 --


### PR DESCRIPTION
The "How it works" section is getting absorbed in the preceding example's code.

![image](https://cloud.githubusercontent.com/assets/41730/16310072/edb3ce7c-391f-11e6-8495-652da00a95e1.png)
