### PR TITLE
tryBlock catches C++ exceptions and returns Either

### DIFF
--- a/inline-c-cpp/test/tests.hs
+++ b/inline-c-cpp/test/tests.hs
@@ -37,6 +37,40 @@ main = Hspec.hspec $ do
 
       result `Hspec.shouldBe` Left C.CppOtherException
 
+    Hspec.it "catch without return" $ do
+      result <- [C.tryBlock| void {
+          throw std::runtime_error("C++ error message");
+        }
+        |]
+
+      result `Hspec.shouldBe` Left (C.CppStdException "C++ error message")
+
+    Hspec.it "try and return without throwing" $ do
+      result <- [C.tryBlock| int {
+          return 123;
+        }
+        |]
+
+      result `Hspec.shouldBe` Right 123
+
+    Hspec.it "return maybe throwing" $ do
+      result <- [C.tryBlock| int {
+          if(1) return 123;
+          else throw std::runtime_error("C++ error message");
+        }
+        |]
+
+      result `Hspec.shouldBe` Right 123
+
+    Hspec.it "return definitely throwing" $ do
+      result <- [C.tryBlock| int {
+          if(0) return 123;
+          else throw std::runtime_error("C++ error message");
+        }
+        |]
+
+      result `Hspec.shouldBe` Left (C.CppStdException "C++ error message")
+
     Hspec.it "code without exceptions works normally" $ do
       result :: Either C.CppException C.CInt <- try $ C.withPtr_ $ \resPtr -> [C.catchBlock|
           *$(int* resPtr) = 0xDEADBEEF;

--- a/inline-c/src/Language/C/Inline/Internal.hs
+++ b/inline-c/src/Language/C/Inline/Internal.hs
@@ -45,6 +45,7 @@ module Language.C.Inline.Internal
     , ParseTypedC(..)
     , parseTypedC
     , runParserInQ
+    , splitTypedC
 
       -- * Utility functions for writing quasiquoters
     , genericQuote
@@ -71,6 +72,8 @@ import qualified Text.Parser.LookAhead as Parser
 import qualified Text.Parser.Token as Parser
 import           Text.PrettyPrint.ANSI.Leijen ((<+>))
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
+import qualified Data.List as L
+import qualified Data.Char as C
 
 -- We cannot use getQ/putQ before 7.10.3 because of <https://ghc.haskell.org/trac/ghc/ticket/10596>
 #define USE_GETQ (__GLASGOW_HASKELL__ > 710 || (__GLASGOW_HASKELL__ == 710 && __GLASGOW_HASKELL_PATCHLEVEL1__ >= 3))
@@ -579,6 +582,14 @@ genericQuote purity build = quoteCode $ \s -> do
           [t| IO $(return retType) |]
         go (paramType : params) = do
           [t| $(return paramType) -> $(go params) |]
+
+splitTypedC :: String -> (String, String)
+  -- ^ Returns the type and the body separately
+splitTypedC s = (trim ty, case body of
+                            [] -> []
+                            r  -> r)
+  where (ty, body) = span (/= '{') s
+        trim x = L.dropWhileEnd C.isSpace (dropWhile C.isSpace x)
 
 ------------------------------------------------------------------------
 -- Utils


### PR DESCRIPTION
The existing C++ exception binding mechanism 'catchBlock' is very inconvenient. Unlike 'block' it doesn't handle return values. It also always rethrows which is very non-idiomatic Haskell and not typesafe.

This introduces tryBlock. It allows return values in almost every case (as long as the value can be constructed using {} or the return type is void). It returns either the exception or the return value which is more typesafe and is the more common error-handling mechanism everyone is used to.