### PR TITLE
Support identifiers for namespace/template of C++

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
   homebrew:
     packages:
     - cairo
+    - cairocffi
     - gsl
 
 matrix:

--- a/inline-c-cpp/inline-c-cpp.cabal
+++ b/inline-c-cpp/inline-c-cpp.cabal
@@ -49,6 +49,6 @@ test-suite tests
   if os(darwin)
     ghc-options: -pgmc=clang++
   extra-libraries:     stdc++
-  cc-options:          -Wall -Werror -optc-xc++ -std=c++11
+  cc-options:          -Wall -Werror
   if os(darwin)
     ld-options: -Wl,-keep_dwarf_unwind

--- a/inline-c-cpp/inline-c-cpp.cabal
+++ b/inline-c-cpp/inline-c-cpp.cabal
@@ -24,6 +24,7 @@ library
                      , inline-c >= 0.6.1.0
                      , template-haskell
                      , safe-exceptions
+                     , containers
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall -optc-std=c++11
@@ -41,6 +42,7 @@ test-suite tests
                      , inline-c-cpp
                      , safe-exceptions
                      , hspec
+                     , containers
   default-language:    Haskell2010
   ghc-options:
     -optc-std=c++11

--- a/inline-c-cpp/inline-c-cpp.cabal
+++ b/inline-c-cpp/inline-c-cpp.cabal
@@ -48,3 +48,5 @@ test-suite tests
     ghc-options: -pgmc=clang++
   extra-libraries:     stdc++
   cc-options:          -Wall -Werror -std=c++11
+  if os(darwin)
+    ld-options: -Wl,-keep_dwarf_unwind

--- a/inline-c-cpp/src/Language/C/Inline/Cpp.hs
+++ b/inline-c-cpp/src/Language/C/Inline/Cpp.hs
@@ -4,6 +4,7 @@
 module Language.C.Inline.Cpp
   ( module Language.C.Inline
   , cppCtx
+  , cppTypePairs
   , using
   ) where
 
@@ -13,6 +14,9 @@ import qualified Language.Haskell.TH.Syntax as TH
 
 import           Language.C.Inline
 import           Language.C.Inline.Context
+import qualified Language.C.Types as CT
+
+import qualified Data.Map as Map
 
 -- | The equivalent of 'C.baseCtx' for C++.  It specifies the @.cpp@
 -- file extension for the C file, so that g++ will decide to build C++
@@ -22,6 +26,7 @@ cppCtx :: Context
 cppCtx = baseCtx <> mempty
   { ctxForeignSrcLang = Just TH.LangCxx
   , ctxOutput = Just $ \s -> "extern \"C\" {\n" ++ s ++ "\n}"
+  , ctxEnableCpp = True
   }
 
 -- | Emits an @using@ directive, e.g.
@@ -31,3 +36,9 @@ cppCtx = baseCtx <> mempty
 -- @
 using :: String -> TH.DecsQ
 using s = verbatim $ "using " ++ s ++ ";"
+
+
+cppTypePairs :: [(CT.CIdentifier, TH.TypeQ)] -> Context
+cppTypePairs typePairs =  mempty {
+  ctxTypesTable = Map.fromList $ map (\(cpp_sym, haskell_sym) -> (CT.TypeName cpp_sym, haskell_sym)) typePairs
+  }

--- a/inline-c-cpp/src/Language/C/Inline/Cpp.hs
+++ b/inline-c-cpp/src/Language/C/Inline/Cpp.hs
@@ -26,7 +26,6 @@ cppCtx :: Context
 cppCtx = baseCtx <> mempty
   { ctxForeignSrcLang = Just TH.LangCxx
   , ctxOutput = Just $ \s -> "extern \"C\" {\n" ++ s ++ "\n}"
-  , ctxEnableCpp = True
   }
 
 -- | Emits an @using@ directive, e.g.

--- a/inline-c-cpp/src/Language/C/Inline/Cpp/Exceptions.hs
+++ b/inline-c-cpp/src/Language/C/Inline/Cpp/Exceptions.hs
@@ -88,6 +88,41 @@ catchBlock = QuasiQuoter
   } where
       unsupported _ = fail "Unsupported quasiquotation."
 
+
+
+{-
+
+Some compilers can not parse "{}" as generalized initializer.(See following the example of test.cpp.)
+"exceptionalValue"-function assigns initial value for numeric types.
+Many numeric types can be initialized with 0.
+
+-- test.cpp --
+int
+test(){
+  try {
+    throw  "Exception\n";
+  }catch(...) {
+    return {};
+  }
+}
+
+---In case of clang -----------
+$ clang++ -c test.cpp
+test.cpp:6:12: warning: generalized initializer lists are a C++11 extension [-Wc++11-extensions]
+    return {};
+           ^~
+test.cpp:6:12: error: scalar initializer cannot be empty
+    return {};
+           ^~
+1 warning and 1 error generated.
+
+---In case of gcc- -----------
+$ g++ -c test.cpp
+test.cpp: In function ‘int test()’:
+test.cpp:6:12: warning: extended initializer lists only available with -std=c++11 or -std=gnu++11
+     return {};
+
+-}
 exceptionalValue :: String -> String
 exceptionalValue typeStr =
   case typeStr of

--- a/inline-c-cpp/src/Language/C/Inline/Cpp/Exceptions.hs
+++ b/inline-c-cpp/src/Language/C/Inline/Cpp/Exceptions.hs
@@ -87,7 +87,50 @@ catchBlock = QuasiQuoter
   , quoteDec = unsupported
   } where
       unsupported _ = fail "Unsupported quasiquotation."
-      
+
+exceptionalValue :: String -> String
+exceptionalValue typeStr =
+  case typeStr of
+    "void" -> ""
+    "char" -> "0"
+    "short" -> "0"
+    "long" -> "0"
+    "int" -> "0"
+    "int8_t" -> "0"
+    "int16_t" -> "0"
+    "int32_t" -> "0"
+    "int64_t" -> "0"
+    "uint8_t" -> "0"
+    "uint16_t" -> "0"
+    "uint32_t" -> "0"
+    "uint64_t" -> "0"
+    "float" -> "0"
+    "double" -> "0"
+    "bool" -> "0"
+    "signed char" -> "0"
+    "signed short" -> "0"
+    "signed int" -> "0"
+    "signed long" -> "0"
+    "unsigned char" -> "0"
+    "unsigned short" -> "0"
+    "unsigned int" -> "0"
+    "unsigned long" -> "0"
+    "size_t" -> "0"
+    "wchar_t" -> "0"
+    "ptrdiff_t" -> "0"
+    "sig_atomic_t" -> "0"
+    "intptr_t" -> "0"
+    "uintptr_t" -> "0"
+    "intmax_t" -> "0"
+    "uintmax_t" -> "0"
+    "clock_t" -> "0"
+    "time_t" -> "0"
+    "useconds_t" -> "0"
+    "suseconds_t" -> "0"
+    "FILE" -> "0"
+    "fpos_t" -> "0"
+    "jmp_buf" -> "0"
+    _ -> "{}"
 
 tryBlockQuoteExp :: String -> Q Exp
 tryBlockQuoteExp blockStr = do
@@ -130,7 +173,7 @@ tryBlockQuoteExp blockStr = do
         , "    size_t message_len = message.size() + 1;"
         , "    *__inline_c_cpp_error_message__ = static_cast<char*>(std::malloc(message_len));"
         , "    std::memcpy(*__inline_c_cpp_error_message__, message.c_str(), message_len);"
-        , if ty == "void" then "return;" else "return {};"
+        , "    return " ++ exceptionalValue ty ++ ";"
         , "  } catch (...) {"
         , "    *__inline_c_cpp_exception_type__ = " ++ show ExTypeOtherException ++ ";"
         , "#if defined(__GNUC__) || defined(__clang__)"
@@ -142,7 +185,7 @@ tryBlockQuoteExp blockStr = do
         , "#else"
         , "    *__inline_c_cpp_error_message__ = NULL;"
         , "#endif"
-        , if ty == "void" then "return;" else "return {};"
+        , "    return " ++ exceptionalValue ty ++ ";"
         , "  }"
         , "}"
         ]

--- a/inline-c-cpp/test/test.h
+++ b/inline-c-cpp/test/test.h
@@ -1,0 +1,8 @@
+namespace Test {
+	class Test {
+	public:
+		Test() {}
+		int get () {return 3;}
+	};
+};
+;

--- a/inline-c-cpp/test/tests.hs
+++ b/inline-c-cpp/test/tests.hs
@@ -1,21 +1,9 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeInType #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PolyKinds #-}
 
 import           Control.Exception.Safe
 import           Control.Monad

--- a/inline-c/src/Language/C/Inline/Context.hs
+++ b/inline-c/src/Language/C/Inline/Context.hs
@@ -201,6 +201,7 @@ baseTypesTable = Map.fromList
   -- along with its documentation's section headers.
   --
   -- Integral types
+  , (C.Bool, [t| CBool |])
   , (C.Char Nothing, [t| CChar |])
   , (C.Char (Just C.Signed), [t| CSChar |])
   , (C.Char (Just C.Unsigned), [t| CUChar |])

--- a/inline-c/src/Language/C/Inline/Internal.hs
+++ b/inline-c/src/Language/C/Inline/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -155,7 +156,11 @@ initialiseModuleState mbContext = do
           Nothing -> fail "inline-c: ModuleState not present (initialiseModuleState)"
           Just ms -> return ms
         let lang = fromMaybe TH.LangC (ctxForeignSrcLang context)
+#if MIN_VERSION_base(4,12,0)
+        TH.addForeignSource lang (concat (reverse (msFileChunks ms)))
+#else
         TH.addForeignFile lang (concat (reverse (msFileChunks ms)))
+#endif
       let moduleState = ModuleState
             { msContext = context
             , msGeneratedNames = 0

--- a/inline-c/src/Language/C/Types.hs
+++ b/inline-c/src/Language/C/Types.hs
@@ -89,6 +89,7 @@ import qualified Language.C.Types.Parse as P
 
 data TypeSpecifier
   = Void
+  | Bool
   | Char (Maybe Sign)
   | Short Sign
   | Int Sign
@@ -216,6 +217,9 @@ untangleDeclarationSpecifiers declSpecs = do
     P.VOID -> do
       checkNoSpecs
       return Void
+    P.BOOL -> do
+      checkNoLength
+      return $ Bool
     P.CHAR -> do
       checkNoLength
       return $ Char mbSign
@@ -370,6 +374,7 @@ tangleTypeSpecifier :: Specifiers -> TypeSpecifier -> [P.DeclarationSpecifier]
 tangleTypeSpecifier (Specifiers storages tyQuals funSpecs) tySpec =
   let pTySpecs = case tySpec of
         Void -> [P.VOID]
+        Bool -> [P.BOOL]
         Char Nothing -> [P.CHAR]
         Char (Just Signed) -> [P.SIGNED, P.CHAR]
         Char (Just Unsigned) -> [P.UNSIGNED, P.CHAR]
@@ -467,6 +472,7 @@ parseType = parameterDeclarationType <$> parseParameterDeclaration
 instance PP.Pretty TypeSpecifier where
   pretty tySpec = case tySpec of
     Void -> "void"
+    Bool -> "bool"
     Char Nothing -> "char"
     Char (Just Signed) -> "signed char"
     Char (Just Unsigned) -> "unsigned char"

--- a/inline-c/src/Language/C/Types.hs
+++ b/inline-c/src/Language/C/Types.hs
@@ -103,8 +103,8 @@ data TypeSpecifier
   | TypeName P.CIdentifier
   | Struct P.CIdentifier
   | Enum P.CIdentifier
-  | Template P.CIdentifier [TypeSpecifier]
-  | TemplateConst String
+  | CxxTemplate P.CIdentifier [TypeSpecifier]
+  | CxxTemplateConst String
   deriving (Typeable, Show, Eq, Ord)
 
 data Specifiers = Specifiers
@@ -209,13 +209,13 @@ untangleDeclarationSpecifiers declSpecs = do
   let checkNoLength =
         when (longs > 0 || shorts > 0) $ illegalSpecifiers "unexpected long/short"
   let type2type dat = case dat of
-        P.Template s args -> do
+        P.CxxTemplate s args -> do
           checkNoSpecs
           args' <- forM args type2type
-          return $ Template s args'
-        P.TemplateConst s -> do
+          return $ CxxTemplate s args'
+        P.CxxTemplateConst s -> do
           checkNoSpecs
-          return $ TemplateConst s
+          return $ CxxTemplateConst s
         P.TypeName s -> do
           checkNoSpecs
           return $ TypeName s
@@ -404,8 +404,8 @@ tangleTypeSpecifier (Specifiers storages tyQuals funSpecs) tySpec =
         TypeName s -> [P.TypeName s]
         Struct s -> [P.Struct s]
         Enum s -> [P.Enum s]
-        Template s types -> [P.Template s (concat (map pTySpecs types))]
-        TemplateConst s -> [P.TemplateConst s]
+        CxxTemplate s types -> [P.CxxTemplate s (concat (map pTySpecs types))]
+        CxxTemplateConst s -> [P.CxxTemplateConst s]
   in map P.StorageClassSpecifier storages ++
      map P.TypeQualifier tyQuals ++
      map P.FunctionSpecifier funSpecs ++
@@ -509,8 +509,8 @@ instance PP.Pretty TypeSpecifier where
     TypeName s -> PP.pretty s
     Struct s -> "struct" <+> PP.pretty s
     Enum s -> "enum" <+> PP.pretty s
-    Template s args -> PP.pretty s <+> "<"  <+>  mconcat (intersperse "," (map PP.pretty args))  <+> ">"
-    TemplateConst s -> PP.pretty s
+    CxxTemplate s args -> PP.pretty s <+> "<"  <+>  mconcat (intersperse "," (map PP.pretty args))  <+> " >"
+    CxxTemplateConst s -> PP.pretty s
 
 instance PP.Pretty UntangleErr where
   pretty err = case err of

--- a/inline-c/src/Language/C/Types/Parse.hs
+++ b/inline-c/src/Language/C/Types/Parse.hs
@@ -282,6 +282,7 @@ storage_class_specifier = msum
 
 data TypeSpecifier
   = VOID
+  | BOOL
   | CHAR
   | SHORT
   | INT
@@ -298,6 +299,7 @@ data TypeSpecifier
 type_specifier :: CParser i m => m TypeSpecifier
 type_specifier = msum
   [ VOID <$ reserve cIdentStyle "void"
+  , BOOL <$ reserve cIdentStyle "bool"
   , CHAR <$ reserve cIdentStyle "char"
   , SHORT <$ reserve cIdentStyle "short"
   , INT <$ reserve cIdentStyle "int"
@@ -514,6 +516,7 @@ instance Pretty StorageClassSpecifier where
 instance Pretty TypeSpecifier where
   pretty tySpec = case tySpec of
    VOID -> "void"
+   BOOL -> "bool"
    CHAR -> "char"
    SHORT -> "short"
    INT -> "int"

--- a/inline-c/test/Language/C/Inline/ContextSpec.hs
+++ b/inline-c/test/Language/C/Inline/ContextSpec.hs
@@ -30,6 +30,8 @@ spec = do
     shouldBeType (cty "int") [t| CInt |]
   Hspec.it "converts simple type correctly (2)" $ do
     shouldBeType (cty "char") [t| CChar |]
+  Hspec.it "converts bool" $ do
+    shouldBeType (cty "bool") [t| CBool |]
   Hspec.it "converts void" $ do
     shouldBeType (cty "void") [t| () |]
   Hspec.it "converts standard library types (1)" $ do

--- a/inline-c/test/Language/C/Inline/ParseSpec.hs
+++ b/inline-c/test/Language/C/Inline/ParseSpec.hs
@@ -85,7 +85,7 @@ spec = do
       -> IO (C.Type C.CIdentifier, [(C.CIdentifier, C.Type C.CIdentifier, ParameterType)], String)
     strictParse s = do
       let ParseTypedC retType pars body =
-            assertParse haskellCParserContext (parseTypedC (ctxAntiQuoters ctx)) s
+            assertParse (haskellCParserContext True) (parseTypedC True (ctxAntiQuoters ctx)) s
       void $ evaluate $ length $ show (retType, pars, body)
       return (retType, pars, body)
 
@@ -94,7 +94,7 @@ spec = do
 
     cty :: String -> C.Type C.CIdentifier
     cty s = C.parameterDeclarationType $
-      assertParse C.cCParserContext C.parseParameterDeclaration s
+      assertParse (C.cCParserContext True) C.parseParameterDeclaration s
 
     shouldMatchParameters
       :: [(C.CIdentifier, C.Type C.CIdentifier, ParameterType)]

--- a/inline-c/test/Language/C/Types/ParseSpec.hs
+++ b/inline-c/test/Language/C/Types/ParseSpec.hs
@@ -38,7 +38,7 @@ spec = do
       ParameterDeclarationWithTypeNames typeNames ty <-
         arbitraryParameterDeclarationWithTypeNames unCIdentifier
       return $ isGoodType ty QC.==>
-        let ty' = assertParse (cCParserContext typeNames) parameter_declaration (prettyOneLine ty)
+        let ty' = assertParse (cCParserContext True typeNames) parameter_declaration (prettyOneLine ty)
         in Types.untangleParameterDeclaration ty == Types.untangleParameterDeclaration ty'
   Hspec.it "parses everything which is pretty-printable (Haskell)" $ do
 #if MIN_VERSION_QuickCheck(2,9,0)
@@ -49,7 +49,7 @@ spec = do
       ParameterDeclarationWithTypeNames typeNames ty <-
         arbitraryParameterDeclarationWithTypeNames unHaskellIdentifier
       return $ isGoodType ty QC.==>
-        let ty' = assertParse (haskellCParserContext typeNames) parameter_declaration (prettyOneLine ty)
+        let ty' = assertParse (haskellCParserContext True typeNames) parameter_declaration (prettyOneLine ty)
         in Types.untangleParameterDeclaration ty == Types.untangleParameterDeclaration ty'
 
 ------------------------------------------------------------------------
@@ -179,7 +179,7 @@ arbitraryIdentifierFrom
   :: (Hashable i, QC.Arbitrary i) => ArbitraryContext i -> QC.Gen i
 arbitraryIdentifierFrom ctx = do
   id' <- QC.arbitrary
-  if isTypeName (acTypeNames ctx) (acIdentToString ctx id')
+  if isTypeName True (acTypeNames ctx) (acIdentToString ctx id')
     then arbitraryIdentifierFrom ctx
     else return id'
 

--- a/inline-c/test/Language/C/Types/ParseSpec.hs
+++ b/inline-c/test/Language/C/Types/ParseSpec.hs
@@ -83,7 +83,7 @@ isGoodHaskellIdentifierType typeNames ty0 =
         Just i -> let
           -- see <https://github.com/fpco/inline-c/pull/97#issuecomment-538648101>
           leadingSegment : _ = splitOn "." (unHaskellIdentifier i)
-          in case cIdentifierFromString leadingSegment of
+          in case cIdentifierFromString False leadingSegment of
            Left{} -> True
            Right seg -> not (seg `HashSet.member` typeNames)
 

--- a/inline-c/test/tests.hs
+++ b/inline-c/test/tests.hs
@@ -66,8 +66,8 @@ main = Hspec.hspec $ do
               Nothing                     -- no postfix
               here
               [t| CInt -> CInt |]
-              (C.quickCParser_ "int" C.parseType)
-              [("x", C.quickCParser_ "int" C.parseType)]
+              (C.quickCParser_ True "int" C.parseType)
+              [("x", C.quickCParser_ True "int" C.parseType)]
               [r| return x + 3; |])
       c_add3 1 `Hspec.shouldBe` 1 + 3
     Hspec.it "inlineExp" $ do
@@ -77,7 +77,7 @@ main = Hspec.hspec $ do
               TH.Safe
               here
               [t| CInt |]
-              (C.quickCParser_ "int" C.parseType)
+              (C.quickCParser_ True "int" C.parseType)
               []
               [r| 1 + 4 |])
       x `Hspec.shouldBe` 1 + 4
@@ -223,3 +223,7 @@ main = Hspec.hspec $ do
         [C.exp| void { $(void (*fp)(int *))($(int *x_ptr)) } |]
         x <- peek x_ptr
         x `Hspec.shouldBe` 42
+    Hspec.it "cpp namespace identifiers" $ do
+      C.cIdentifierFromString True "Test::Test"  `Hspec.shouldBe`  Right "Test::Test"
+    Hspec.it "cpp template identifiers" $ do
+      C.cIdentifierFromString True "std::vector"  `Hspec.shouldBe`  Right "std::vector"


### PR DESCRIPTION
This PR supports identifiers for namespace/template of C++.
We want to use libtorch library which uses various Tensor classes(at::Tensor, torch::Tensor, caffe2::Tensor and so on).

I think cIdentLetter should support c types only and this modification is hackey.
But the implementation of identifier is not pluggable.

Could you merge this PR?
