### PR TITLE
Get test suite to compile on macos and CI it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,33 @@ addons:
     - libgmp-dev
     - libgsl0-dev
     - libcairo2-dev
+  homebrew:
+    packages:
+    - cairo
+    - gsl
 
-env:
-- ARGS="--flag inline-c:gsl-example"
-- ARGS="--stack-yaml stack-lts-12.14.yaml --flag inline-c:gsl-example"
-# gtk2hs-buildtools is not present in nightly a bit of a pain to install,
-# skip it for now
-- ARGS="--stack-yaml stack-nightly-2018-10-24.yaml"
+
+matrix:
+  include:
+   - env: ARGS="--flag inline-c:gsl-example"
+   - env: ARGS="--stack-yaml stack-lts-12.14.yaml --flag inline-c:gsl-example"
+   # gtk2hs-buildtools is not present in nightly a bit of a pain to install,
+   # skip it for now
+   - env: ARGS="--stack-yaml stack-nightly-2018-10-24.yaml"
+   - env: ARGS="--flag inline-c:gsl-example"
+     os: osx
 
 before_install:
 # Download and unpack the stack executable
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH
-- travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+- |
+  if [ `uname` = "Darwin" ]
+  then
+    travis_retry curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+  else
+    travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  fi
 
 # This line does all of the work: installs GHC if necessary, build the library,
 # executables, and test suites, and runs the test suites. --no-terminal works

--- a/inline-c-cpp/inline-c-cpp.cabal
+++ b/inline-c-cpp/inline-c-cpp.cabal
@@ -20,14 +20,17 @@ source-repository head
 library
   exposed-modules:     Language.C.Inline.Cpp
                        Language.C.Inline.Cpp.Exceptions
-  ghc-options:         -Wall
   build-depends:       base >=4.7 && <5
                      , inline-c >= 0.6.1.0
                      , template-haskell
                      , safe-exceptions
   hs-source-dirs:      src
   default-language:    Haskell2010
-  cc-options:          -Wall -Werror
+  ghc-options:         -Wall -optc-std=c++11
+  if os(darwin)
+    -- avoid https://gitlab.haskell.org/ghc/ghc/issues/11829
+    ld-options:        -Wl,-keep_dwarf_unwind 
+    ghc-options:       -pgmc=clang++
 
 test-suite tests
   type:                exitcode-stdio-1.0
@@ -39,5 +42,9 @@ test-suite tests
                      , safe-exceptions
                      , hspec
   default-language:    Haskell2010
+  ghc-options:
+    -optc-std=c++11
+  if os(darwin)
+    ghc-options: -pgmc=clang++
   extra-libraries:     stdc++
-  cc-options:          -Wall -Werror
+  cc-options:          -Wall -Werror -std=c++11

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,9 @@
-resolver: lts-11.22
+resolver: lts-13.19
 packages:
 - inline-c
 - inline-c-cpp
 - sample-cabal-project
+extra-deps:
+- Chart-cairo-1.9.1
+- cairo-0.13.6.0
+- gtk2hs-buildtools-0.13.5.0


### PR DESCRIPTION
Fixes #75 with working around Cabal bug.

But the test suite fails:

```
Basic C++
Hello, world!3
  Hello World
Exception handling
libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: C++ error message                               
```
