### PR TITLE
base 4.13 compatibility

### DIFF
--- a/inline-c/src/Language/C/Inline/Internal.hs
+++ b/inline-c/src/Language/C/Inline/Internal.hs
@@ -539,7 +539,11 @@ parseTypedC antiQs = do
     -- The @m@ is polymorphic because we use this both for the plain
     -- parser and the StateT parser we use above.  We only need 'fail'.
     purgeHaskellIdentifiers
+#if MIN_VERSION_base(4,13,0)
+      :: forall n. MonadFail n
+#else
       :: forall n. (Applicative n, Monad n)
+#endif
       => C.Type HaskellIdentifier -> n (C.Type C.CIdentifier)
     purgeHaskellIdentifiers cTy = for cTy $ \hsIdent -> do
       let hsIdentS = unHaskellIdentifier hsIdent
@@ -555,9 +559,9 @@ quoteCode
   -> TH.QuasiQuoter
 quoteCode p = TH.QuasiQuoter
   { TH.quoteExp = p
-  , TH.quotePat = fail "inline-c: quotePat not implemented (quoteCode)"
-  , TH.quoteType = fail "inline-c: quoteType not implemented (quoteCode)"
-  , TH.quoteDec = fail "inline-c: quoteDec not implemented (quoteCode)"
+  , TH.quotePat = const $ fail "inline-c: quotePat not implemented (quoteCode)"
+  , TH.quoteType = const $ fail "inline-c: quoteType not implemented (quoteCode)"
+  , TH.quoteDec = const $ fail "inline-c: quoteDec not implemented (quoteCode)"
   }
 
 genericQuote

--- a/inline-c/src/Language/C/Types/Parse.hs
+++ b/inline-c/src/Language/C/Types/Parse.hs
@@ -175,6 +175,9 @@ type CParser i m =
   , TokenParsing m
   , LookAheadParsing m
   , MonadReader (CParserContext i) m
+#if (MIN_VERSION_base(4,13,0))
+  , MonadFail m
+#endif
   , Hashable i
   )
 


### PR DESCRIPTION
This patch adds compatibility with `base` 4.13, which removes `fail` from `Monad`, and fixes a couple of places where you were accidentally using `fail` in the `(->)e` monad, rather than in `Q`, to properly `fail` in `Q`.