### PR TITLE
Rethrow Haskell exceptions

### DIFF
--- a/inline-c-cpp/cxx-src/HaskellException.cxx
+++ b/inline-c-cpp/cxx-src/HaskellException.cxx
@@ -2,17 +2,17 @@
 #include "HaskellException.hxx"
 
 HaskellException::HaskellException(std::string renderedExceptionIn, void *haskellExceptionStablePtrIn)
-  : renderedException(renderedExceptionIn)
+  : displayExceptionValue(renderedExceptionIn)
   , haskellExceptionStablePtr(new HaskellStablePtr(haskellExceptionStablePtrIn))
 {
 }
 
 HaskellException::HaskellException(const HaskellException &other)
-  : renderedException(other.renderedException)
+  : displayExceptionValue(other.displayExceptionValue)
   , haskellExceptionStablePtr(other.haskellExceptionStablePtr)
 {
 }
 
 const char* HaskellException::what() const noexcept {
-  return renderedException.c_str();
+  return displayExceptionValue.c_str();
 }

--- a/inline-c-cpp/cxx-src/HaskellException.cxx
+++ b/inline-c-cpp/cxx-src/HaskellException.cxx
@@ -1,0 +1,18 @@
+
+#include "HaskellException.hxx"
+
+HaskellException::HaskellException(std::string renderedExceptionIn, void *haskellExceptionStablePtrIn)
+  : renderedException(renderedExceptionIn)
+  , haskellExceptionStablePtr(new HaskellStablePtr(haskellExceptionStablePtrIn))
+{
+}
+
+HaskellException::HaskellException(const HaskellException &other)
+  : renderedException(other.renderedException)
+  , haskellExceptionStablePtr(other.haskellExceptionStablePtr)
+{
+}
+
+const char* HaskellException::what() const noexcept {
+  return renderedException.c_str();
+}

--- a/inline-c-cpp/cxx-src/HaskellStablePtr.cxx
+++ b/inline-c-cpp/cxx-src/HaskellStablePtr.cxx
@@ -1,0 +1,7 @@
+
+#include "HaskellStablePtr.hxx"
+#include "HsFFI.h"
+
+HaskellStablePtr::~HaskellStablePtr() {
+  hs_free_stable_ptr(stablePtr);
+}

--- a/inline-c-cpp/cxx-src/HaskellStablePtr.cxx
+++ b/inline-c-cpp/cxx-src/HaskellStablePtr.cxx
@@ -3,5 +3,7 @@
 #include "HsFFI.h"
 
 HaskellStablePtr::~HaskellStablePtr() {
-  hs_free_stable_ptr(stablePtr);
+  if (stablePtr != STABLE_PTR_NULL) {
+    hs_free_stable_ptr(stablePtr);
+  }
 }

--- a/inline-c-cpp/include/HaskellException.hxx
+++ b/inline-c-cpp/include/HaskellException.hxx
@@ -8,9 +8,9 @@
 class HaskellException : public std::exception {
 public:
   std::shared_ptr<HaskellStablePtr> haskellExceptionStablePtr;
-  std::string renderedException;
+  std::string displayExceptionValue;
 
-  HaskellException(std::string renderedException, void *haskellExceptionStablePtr);
+  HaskellException(std::string displayExceptionValue, void *haskellExceptionStablePtr);
   HaskellException(const HaskellException &);
   virtual const char* what() const noexcept override;
 

--- a/inline-c-cpp/include/HaskellException.hxx
+++ b/inline-c-cpp/include/HaskellException.hxx
@@ -1,0 +1,17 @@
+
+#pragma once
+
+#include "HaskellStablePtr.hxx"
+#include <memory>
+#include <string>
+
+class HaskellException : public std::exception {
+public:
+  std::shared_ptr<HaskellStablePtr> haskellExceptionStablePtr;
+  std::string renderedException;
+
+  HaskellException(std::string renderedException, void *haskellExceptionStablePtr);
+  HaskellException(const HaskellException &);
+  virtual const char* what() const noexcept override;
+
+};

--- a/inline-c-cpp/include/HaskellException.hxx
+++ b/inline-c-cpp/include/HaskellException.hxx
@@ -5,6 +5,16 @@
 #include <memory>
 #include <string>
 
+/* A representation of a Haskell exception (SomeException), with a precomputed
+   exception message from Control.Exception.displayException.
+
+   The std::exception requires that retrieving the message does not mutate the
+   exception object and does not throw exceptions.
+
+   This class uses std::shared_ptr for the exception, because its callers can
+   not know in advance where and how often the exception will be copied, or when
+   it is released.
+ */
 class HaskellException : public std::exception {
 public:
   std::shared_ptr<HaskellStablePtr> haskellExceptionStablePtr;

--- a/inline-c-cpp/include/HaskellStablePtr.hxx
+++ b/inline-c-cpp/include/HaskellStablePtr.hxx
@@ -1,13 +1,38 @@
 
 #pragma once
 
-struct HaskellStablePtr {
-  void *stablePtr;
+#include "HsFFI.h"
 
-  /* Takes ownership of a stable pointer */
-  inline HaskellStablePtr(void *s) {
+#ifndef STABLE_PTR_NULL
+#define STABLE_PTR_NULL (static_cast<HsStablePtr>((void *)0))
+#endif
+
+/* This is like a newtype that adds a C++ destructor, allowing C++ to call
+   hs_free_stable_ptr when the lifetime ends.
+
+   If you need to pass HaskellStablePtr around, you need to use something like
+   std::shared_ptr<HaskellStablePtr> to avoid copying the HaskellStablePtr.
+
+   WARNING: If you copy HaskellStablePtr, you must call the original.setNull()
+            method in order to prevent a premature/double free when original
+            goes out of scope. This does make the original object invalid.
+ */
+struct HaskellStablePtr {
+  HsStablePtr stablePtr;
+
+  /* Takes ownership of a stable pointer. */
+  inline HaskellStablePtr(HsStablePtr s) {
     stablePtr = s;
   }
-  /* Calls hs_free_stable_ptr */
+
+  /* Calls hs_free_stable_ptr if this.stablePtr is not NULL. */
   ~HaskellStablePtr();
+
+  inline void setNull() {
+    stablePtr = STABLE_PTR_NULL;
+  }
+
+  operator bool() const {
+    return stablePtr != STABLE_PTR_NULL;
+  }
 };

--- a/inline-c-cpp/include/HaskellStablePtr.hxx
+++ b/inline-c-cpp/include/HaskellStablePtr.hxx
@@ -1,0 +1,13 @@
+
+#pragma once
+
+struct HaskellStablePtr {
+  void *stablePtr;
+
+  /* Takes ownership of a stable pointer */
+  inline HaskellStablePtr(void *s) {
+    stablePtr = s;
+  }
+  /* Calls hs_free_stable_ptr */
+  ~HaskellStablePtr();
+};

--- a/inline-c-cpp/inline-c-cpp.cabal
+++ b/inline-c-cpp/inline-c-cpp.cabal
@@ -29,8 +29,8 @@ library
   ghc-options:         -Wall -optc-std=c++11
   include-dirs:        include
   install-includes:    HaskellException.hxx HaskellStablePtr.hxx
-  cxx-sources:         cxx-src/HaskellException.cxx cxx-src/HaskellStablePtr.cxx
   extra-libraries:     stdc++
+  c-sources:           cxx-src/HaskellException.cxx cxx-src/HaskellStablePtr.cxx
   cc-options:          -Wall -std=c++11
   if os(darwin)
     -- avoid https://gitlab.haskell.org/ghc/ghc/issues/11829

--- a/inline-c-cpp/inline-c-cpp.cabal
+++ b/inline-c-cpp/inline-c-cpp.cabal
@@ -31,6 +31,7 @@ library
   install-includes:    HaskellException.hxx HaskellStablePtr.hxx
   cxx-sources:         cxx-src/HaskellException.cxx cxx-src/HaskellStablePtr.cxx
   extra-libraries:     stdc++
+  cc-options:          -Wall -std=c++11
   if os(darwin)
     -- avoid https://gitlab.haskell.org/ghc/ghc/issues/11829
     ld-options:        -Wl,-keep_dwarf_unwind

--- a/inline-c-cpp/inline-c-cpp.cabal
+++ b/inline-c-cpp/inline-c-cpp.cabal
@@ -1,5 +1,6 @@
+cabal-version:       2.1
 name:                inline-c-cpp
-version:             0.3.0.2
+version:             0.4.0.0
 synopsis:            Lets you embed C++ code into Haskell.
 description:         Utilities to inline C++ code into Haskell using inline-c.  See
                      tests for example on how to build.
@@ -11,7 +12,6 @@ copyright:           (c) 2015-2016 FP Complete Corporation, (c) 2017-2019 France
 category:            FFI
 tested-with:         GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5
 build-type:          Simple
-cabal-version:       >=1.10
 
 source-repository head
   type:     git
@@ -27,6 +27,10 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:         -Wall -optc-std=c++11
+  include-dirs:        include
+  install-includes:    HaskellException.hxx HaskellStablePtr.hxx
+  cxx-sources:         cxx-src/HaskellException.cxx cxx-src/HaskellStablePtr.cxx
+  extra-libraries:     stdc++
   if os(darwin)
     -- avoid https://gitlab.haskell.org/ghc/ghc/issues/11829
     ld-options:        -Wl,-keep_dwarf_unwind

--- a/inline-c-cpp/test/tests.hs
+++ b/inline-c-cpp/test/tests.hs
@@ -6,6 +6,8 @@ import           Control.Exception.Safe
 import           Control.Monad
 import qualified Language.C.Inline.Cpp as C
 import qualified Language.C.Inline.Cpp.Exceptions as C
+import           Foreign.C.String (withCString)
+import           Foreign.StablePtr (StablePtr, newStablePtr, castStablePtrToPtr)
 import qualified Test.Hspec as Hspec
 import           Data.List (isInfixOf)
 
@@ -13,6 +15,10 @@ C.context C.cppCtx
 
 C.include "<iostream>"
 C.include "<stdexcept>"
+
+data MyCustomException = MyCustomException Int
+  deriving (Eq, Show, Typeable)
+instance Exception MyCustomException
 
 main :: IO ()
 main = Hspec.hspec $ do
@@ -29,14 +35,14 @@ main = Hspec.hspec $ do
         throw std::runtime_error("C++ error message");
         |]
 
-      result `Hspec.shouldBe` Left (C.CppStdException "Exception: C++ error message; type: std::runtime_error")
+      result `shouldBeCppStdException` "Exception: C++ error message; type: std::runtime_error"
 
     Hspec.it "non-exceptions are caught (unsigned int)" $ do
       result <- try [C.catchBlock|
         throw 0xDEADBEEF;
         |]
 
-      result `Hspec.shouldBe` Left (C.CppOtherException (Just "unsigned int"))
+      result `shouldBeCppOtherException` (Just "unsigned int")
 
     Hspec.it "non-exceptions are caught (std::string)" $ do
       result <- try [C.catchBlock|
@@ -53,7 +59,7 @@ main = Hspec.hspec $ do
         }
         |]
 
-      result `Hspec.shouldBe` Left (C.CppStdException "Exception: C++ error message; type: std::runtime_error")
+      result `shouldBeCppStdException` "Exception: C++ error message; type: std::runtime_error"
 
     Hspec.it "try and return without throwing (pure)" $ do
       result <- [C.tryBlock| int {
@@ -61,7 +67,7 @@ main = Hspec.hspec $ do
         }
         |]
 
-      result `Hspec.shouldBe` Right 123
+      result `shouldBeRight` 123
 
     Hspec.it "return maybe throwing (pure)" $ do
       result <- [C.tryBlock| int {
@@ -70,7 +76,7 @@ main = Hspec.hspec $ do
         }
         |]
 
-      result `Hspec.shouldBe` Right 123
+      result `shouldBeRight` 123
 
     Hspec.it "return definitely throwing (pure)" $ do
       result <- [C.tryBlock| int {
@@ -79,7 +85,7 @@ main = Hspec.hspec $ do
         }
         |]
 
-      result `Hspec.shouldBe` Left (C.CppStdException "Exception: C++ error message; type: std::runtime_error")
+      result `shouldBeCppStdException` "Exception: C++ error message; type: std::runtime_error"
 
     Hspec.it "catch without return (pure)" $ do
       result <- [C.tryBlock| void {
@@ -87,7 +93,7 @@ main = Hspec.hspec $ do
         }
         |]
 
-      result `Hspec.shouldBe` Left (C.CppStdException "Exception: C++ error message; type: std::runtime_error")
+      result `shouldBeCppStdException` "Exception: C++ error message; type: std::runtime_error"
 
     Hspec.it "try and return without throwing (throw)" $ do
       result :: Either C.CppException C.CInt <- try [C.throwBlock| int {
@@ -95,7 +101,7 @@ main = Hspec.hspec $ do
         }
         |]
 
-      result `Hspec.shouldBe` Right 123
+      result `shouldBeRight` 123
 
     Hspec.it "return maybe throwing (throw)" $ do
       result :: Either C.CppException C.CInt <- try [C.throwBlock| int {
@@ -104,7 +110,7 @@ main = Hspec.hspec $ do
         }
         |]
 
-      result `Hspec.shouldBe` Right 123
+      result `shouldBeRight` 123
 
     Hspec.it "return definitely throwing (throw)" $ do
       result <- try [C.throwBlock| int {
@@ -113,7 +119,45 @@ main = Hspec.hspec $ do
         }
         |]
 
-      result `Hspec.shouldBe` Left (C.CppStdException "Exception: C++ error message; type: std::runtime_error")
+      result `shouldBeCppStdException` "Exception: C++ error message; type: std::runtime_error"
+
+    Hspec.it "return throwing Haskell" $ do
+      let exc = toException $ userError "This is from Haskell"
+
+      let doIt = withCString (displayException exc) $ \renderedException -> do
+
+                    stablePtr <- newStablePtr exc
+                    let stablePtr' = castStablePtrToPtr stablePtr
+
+                    [C.throwBlock| int {
+                        if(0) return 123;
+                        else throw HaskellException(HaskellException(std::string($(const char *renderedException)), $(void *stablePtr')));
+                      }
+                      |]
+
+      let isTheError e | e == userError "This is from Haskell" = True
+          isTheError _ = False
+
+      doIt `Hspec.shouldThrow` isTheError
+
+    Hspec.it "return throwing custom Haskell exception" $ do
+      let exc = toException $ MyCustomException 42
+
+      let doIt = withCString (displayException exc) $ \renderedException -> do
+
+                    stablePtr <- newStablePtr exc
+                    let stablePtr' = castStablePtrToPtr stablePtr
+
+                    [C.throwBlock| int {
+                        if(0) return 123;
+                        else throw HaskellException(HaskellException(std::string($(const char *renderedException)), $(void *stablePtr')));
+                      }
+                      |]
+
+      let isTheError (MyCustomException 42) = True
+          isTheError _ = False
+
+      doIt `Hspec.shouldThrow` isTheError
 
     Hspec.it "catch without return (throw)" $ do
       result <- try [C.throwBlock| void {
@@ -121,11 +165,32 @@ main = Hspec.hspec $ do
         }
         |]
 
-      result `Hspec.shouldBe` Left (C.CppStdException "Exception: C++ error message; type: std::runtime_error")
+      result `shouldBeCppStdException` "Exception: C++ error message; type: std::runtime_error"
 
     Hspec.it "code without exceptions works normally" $ do
       result :: Either C.CppException C.CInt <- try $ C.withPtr_ $ \resPtr -> [C.catchBlock|
           *$(int* resPtr) = 0xDEADBEEF;
         |]
 
-      result `Hspec.shouldBe` Right 0xDEADBEEF
+      result `shouldBeRight` 0xDEADBEEF
+
+tag :: C.CppException -> String
+tag (C.CppStdException {}) = "CppStdException"
+tag (C.CppHaskellException {}) = "CppHaskellException"
+tag (C.CppOtherException {}) = "CppStdException"
+
+shouldBeCppStdException :: Either C.CppException a -> String -> IO ()
+shouldBeCppStdException (Left (C.CppStdException actualMsg)) expectedMsg = do
+  actualMsg `Hspec.shouldBe` expectedMsg
+shouldBeCppStdException (Left x) expectedMsg = tag x `Hspec.shouldBe` ("CppStdException " <> show expectedMsg)
+shouldBeCppStdException (Right _) expectedMsg = "Right _" `Hspec.shouldBe` ("Left (CppStdException " <> show expectedMsg <> ")")
+
+shouldBeCppOtherException :: Either C.CppException a -> Maybe String -> IO ()
+shouldBeCppOtherException (Left (C.CppOtherException actualType)) expectedType = do
+  actualType `Hspec.shouldBe` expectedType
+shouldBeCppOtherException (Left x) expectedType = tag x `Hspec.shouldBe` ("CppOtherException " <> show expectedType)
+shouldBeCppOtherException (Right _) expectedType = "Right _" `Hspec.shouldBe` ("Left (CppOtherException " <> show expectedType <> ")")
+
+shouldBeRight :: (Eq a, Show a) => Either C.CppException a -> a -> IO ()
+shouldBeRight (Right actual) expected = actual `Hspec.shouldBe` expected
+shouldBeRight (Left e) expected = ("Left (" <> tag e <> " {})") `Hspec.shouldBe` ("Right " <> (show expected))


### PR DESCRIPTION
This adds the ability to throw any Haskell exception from C++ code.

 - Removes instances `Eq CppException`, `Ord CppException` because those can
   not be implemented for the  CppHaskellException SomeException
   constructor.
 - Currently requires some boilerplate to actually throw a Haskell
   exception, but at least it can be done.

Functions to make the throwing easier/automatic can be built on top of this.
