### PR TITLE
Show the string of parse-error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ before_install:
 # This line does all of the work: installs GHC if necessary, build the library,
 # executables, and test suites, and runs the test suites. --no-terminal works
 # around some quirks in Travis's terminal implementation.
-script: stack --no-terminal --install-ghc test --haddock $ARGS
+script: stack --no-terminal --install-ghc test --haddock $ARGS --ta --seed=996343399
 
 # Caching so the next build will be fast too.
 cache:

--- a/inline-c/test/Language/C/Types/ParseSpec.hs
+++ b/inline-c/test/Language/C/Types/ParseSpec.hs
@@ -60,7 +60,7 @@ assertParse
   => CParserContext i -> (forall m. CParser i m => m a) -> String -> a
 assertParse ctx p s =
   case runCParser ctx "spec" s (lift spaces *> p <* lift eof) of
-    Left err -> error $ "Parse error (assertParse): " ++ show err
+    Left err -> error $ "Parse error (assertParse): " ++ show err ++ " parsed string = " ++ s
     Right x -> x
 
 prettyOneLine :: PP.Pretty a => a -> String


### PR DESCRIPTION
Quickcheck fails, when we use the seed(996343399).
But current test-code does not show the failed string(`GeOIop36R9BfZ2zktb61 T.FhQ.l`).
This PR uses the seed and shows the failed string.