### PR TITLE
explicitly provide language to `cc`, should fix #102

### DIFF
--- a/inline-c-cpp/inline-c-cpp.cabal
+++ b/inline-c-cpp/inline-c-cpp.cabal
@@ -26,7 +26,7 @@ library
                      , safe-exceptions
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options:         -Wall -optc-std=c++11
+  ghc-options:         -Wall -optc-xc++ -optc-std=c++11
   if os(darwin)
     -- avoid https://gitlab.haskell.org/ghc/ghc/issues/11829
     ld-options:        -Wl,-keep_dwarf_unwind
@@ -47,4 +47,4 @@ test-suite tests
   if os(darwin)
     ghc-options: -pgmc=clang++
   extra-libraries:     stdc++
-  cc-options:          -Wall -Werror -std=c++11
+  cc-options:          -Wall -Werror -optc-xc++ -std=c++11


### PR DESCRIPTION
As suggested in
<https://github.com/fpco/inline-c/issues/102#issuecomment-545066499>.