### PR TITLE
Reduce generated codes of c++ to speed up compilation

### DIFF
--- a/inline-c-cpp/cxx-src/HaskellException.cxx
+++ b/inline-c-cpp/cxx-src/HaskellException.cxx
@@ -1,5 +1,20 @@
-
 #include "HaskellException.hxx"
+
+// see
+// <https://stackoverflow.com/questions/28166565/detect-gcc-as-opposed-to-msvc-clang-with-macro>
+// regarding how to detect g++ or clang.
+// 
+// the defined(__clang__) should actually be redundant, since apparently it also
+// defines GNUC, but but let's be safe.
+
+#include <cstring>
+#include <cstdlib>
+
+#if defined(__GNUC__) || defined(__clang__)
+#include <cxxabi.h>
+#include <string>
+#endif
+
 
 HaskellException::HaskellException(std::string renderedExceptionIn, void *haskellExceptionStablePtrIn)
   : haskellExceptionStablePtr(new HaskellStablePtr(haskellExceptionStablePtrIn))
@@ -15,4 +30,29 @@ HaskellException::HaskellException(const HaskellException &other)
 
 const char* HaskellException::what() const noexcept {
   return displayExceptionValue.c_str();
+}
+
+void setMessageOfStdException(std::exception &e,char** __inline_c_cpp_error_message__){
+#if defined(__GNUC__) || defined(__clang__)
+  int demangle_status;
+  const char* demangle_result = abi::__cxa_demangle(abi::__cxa_current_exception_type()->name(), 0, 0, &demangle_status);
+  std::string message = "Exception: " + std::string(e.what()) + "; type: " + std::string(demangle_result);
+#else
+  std::string message = "Exception: " + std::string(e.what()) + "; type: not available (please use g++ or clang)";
+#endif
+  size_t message_len = message.size() + 1;
+  *__inline_c_cpp_error_message__ = static_cast<char*>(std::malloc(message_len));
+  std::memcpy(*__inline_c_cpp_error_message__, message.c_str(), message_len);
+}
+
+void setMessageOfOtherException(char** __inline_c_cpp_error_message__){
+#if defined(__GNUC__) || defined(__clang__)
+  int demangle_status;
+  const char* message = abi::__cxa_demangle(abi::__cxa_current_exception_type()->name(), 0, 0, &demangle_status);
+  size_t message_len = strlen(message) + 1;
+  *__inline_c_cpp_error_message__ = static_cast<char*>(std::malloc(message_len));
+  std::memcpy(*__inline_c_cpp_error_message__, message, message_len);
+#else
+  *__inline_c_cpp_error_message__ = NULL;
+#endif
 }

--- a/inline-c-cpp/cxx-src/HaskellException.cxx
+++ b/inline-c-cpp/cxx-src/HaskellException.cxx
@@ -32,10 +32,22 @@ const char* HaskellException::what() const noexcept {
   return displayExceptionValue.c_str();
 }
 
+
+// see
+// <https://stackoverflow.com/questions/561997/determining-exception-type-after-the-exception-is-caught/47164539#47164539>
+// regarding how to show the type of an exception.
+
+#if defined(__GNUC__) || defined(__clang__)
+const char* currentExceptionTypeName()
+{
+  int demangle_status;
+  return abi::__cxa_demangle(abi::__cxa_current_exception_type()->name(), 0, 0, &demangle_status);
+}
+#endif
+
 void setMessageOfStdException(std::exception &e,char** __inline_c_cpp_error_message__){
 #if defined(__GNUC__) || defined(__clang__)
-  int demangle_status;
-  const char* demangle_result = abi::__cxa_demangle(abi::__cxa_current_exception_type()->name(), 0, 0, &demangle_status);
+  const char* demangle_result = currentExceptionTypeName();
   std::string message = "Exception: " + std::string(e.what()) + "; type: " + std::string(demangle_result);
 #else
   std::string message = "Exception: " + std::string(e.what()) + "; type: not available (please use g++ or clang)";
@@ -47,8 +59,7 @@ void setMessageOfStdException(std::exception &e,char** __inline_c_cpp_error_mess
 
 void setMessageOfOtherException(char** __inline_c_cpp_error_message__){
 #if defined(__GNUC__) || defined(__clang__)
-  int demangle_status;
-  const char* message = abi::__cxa_demangle(abi::__cxa_current_exception_type()->name(), 0, 0, &demangle_status);
+  const char* message = currentExceptionTypeName();
   size_t message_len = strlen(message) + 1;
   *__inline_c_cpp_error_message__ = static_cast<char*>(std::malloc(message_len));
   std::memcpy(*__inline_c_cpp_error_message__, message, message_len);

--- a/inline-c-cpp/include/HaskellException.hxx
+++ b/inline-c-cpp/include/HaskellException.hxx
@@ -4,6 +4,7 @@
 #include "HaskellStablePtr.hxx"
 #include <memory>
 #include <string>
+#include <exception>
 
 /* A representation of a Haskell exception (SomeException), with a precomputed
    exception message from Control.Exception.displayException.
@@ -25,3 +26,6 @@ public:
   virtual const char* what() const noexcept override;
 
 };
+
+void setMessageOfStdException(std::exception &e,char** __inline_c_cpp_error_message__);
+void setMessageOfOtherException(char** __inline_c_cpp_error_message__);

--- a/inline-c-cpp/src/Language/C/Inline/Cpp/Exceptions.hs
+++ b/inline-c-cpp/src/Language/C/Inline/Cpp/Exceptions.hs
@@ -165,9 +165,6 @@ tryBlockQuoteExp blockStr = do
   typePtrVarName <- newName "exTypePtr"
   msgPtrVarName <- newName "msgPtr"
   haskellExPtrVarName <- newName "haskellExPtr"
-  -- see
-  -- <https://stackoverflow.com/questions/561997/determining-exception-type-after-the-exception-is-caught/47164539#47164539>
-  -- regarding how to show the type of an exception.
   let inlineCStr = unlines
         [ ty ++ " {"
         , "  int* __inline_c_cpp_exception_type__ = $(int* " ++ nameBase typePtrVarName ++ ");"


### PR DESCRIPTION
When we uses c++ exceptions with tryBlock, code for error message handling is generated for each function.
This PR reduces the code of error message handling to speed up compilation of c++.