### PR TITLE
Support for template with pointers.

### DIFF
--- a/inline-c-cpp/test/tests.hs
+++ b/inline-c-cpp/test/tests.hs
@@ -259,6 +259,17 @@ main = Hspec.hspec $ do
       hsDoubleVec <- StdVector.toVector doubleVec
       VS.toList hsDoubleVec `shouldBe` [ 4.3, 6.7 ]
 
+  Hspec.it "Template with pointers" $ do
+    pt <- [C.block| std::vector<int*>* {
+        return new std::vector<int*>();
+      } |] :: IO (Ptr (StdVector.CStdVector (Ptr C.CInt)))
+    [C.block| void {
+        int *a = new int;
+        *a = 100;
+        $(std::vector<int*>* pt)->push_back(a);
+        std::cout << *((*$(std::vector<int*>* pt))[0]) << std::endl;
+      } |]
+
 tag :: C.CppException -> String
 tag (C.CppStdException {}) = "CppStdException"
 tag (C.CppHaskellException {}) = "CppHaskellException"

--- a/inline-c/src/Language/C/Inline/Context.hs
+++ b/inline-c/src/Language/C/Inline/Context.hs
@@ -299,6 +299,10 @@ convertType purity cTypes = runMaybeT . go
       C.TypeSpecifier _specs (C.TemplateConst num) -> do
         let n = (TH.LitT (TH.NumTyLit (read num)))
         lift [t| $(return n) |]
+      C.TypeSpecifier _specs (C.TemplatePointer cSpec) -> do
+        case Map.lookup cSpec cTypes of
+          Nothing -> mzero
+          Just ty -> lift [t| Ptr $(ty) |]
       C.TypeSpecifier _specs cSpec ->
         case Map.lookup cSpec cTypes of
           Nothing -> mzero

--- a/inline-c/test/Language/C/Inline/ParseSpec.hs
+++ b/inline-c/test/Language/C/Inline/ParseSpec.hs
@@ -41,6 +41,8 @@ spec = do
       cExp `shouldMatchBody` " (int) ceil(x[a-z0-9_]+ \\+ ((double) y[a-z0-9_]+)) "
     Hspec.it "accepts anti quotes" $ do
       void $ goodParse [r| int { $(int x) } |]
+    Hspec.it "accepts anti quotes with pointer" $ do
+      void $ goodParse [r| int* { $(int* x) } |]
     Hspec.it "rejects if bad braces (1)" $ do
       badParse [r| int x |]
     Hspec.it "rejects if bad braces (2)" $ do


### PR DESCRIPTION
Support for template with pointers like `std::vector<int*>`.