### PR TITLE
Change pure calls to use the faster unsafeDupablePerformIO

### DIFF
--- a/inline-c/src/Language/C/Inline.hs
+++ b/inline-c/src/Language/C/Inline.hs
@@ -241,10 +241,15 @@ exp = genericQuote IO $ inlineExp TH.Safe
 
 -- | Variant of 'exp', for use with expressions known to have no side effects.
 --
--- BEWARE: use this function with caution, only when you know what you are
+-- __BEWARE__: Use this function with caution, only when you know what you are
 -- doing. If an expression does in fact have side-effects, then indiscriminate
 -- use of 'pure' may endanger referential transparency, and in principle even
--- type safety.
+-- type safety. Also note that the function might be called multiple times,
+-- given that 'System.IO.Unsafe.unsafeDupablePerformIO' is used to call the
+-- provided C code.  Please refer to the documentation for
+-- 'System.IO.Unsafe.unsafePerformIO' for more details.
+-- [unsafeDupablePerformIO is used to ensure good performance using the
+-- threaded runtime](https://github.com/fpco/inline-c/issues/115).
 pure :: TH.QuasiQuoter
 pure = genericQuote Pure $ inlineExp TH.Safe
 

--- a/inline-c/src/Language/C/Inline/Internal.hs
+++ b/inline-c/src/Language/C/Inline/Internal.hs
@@ -70,7 +70,7 @@ import           Data.Typeable (Typeable, cast)
 import qualified Language.Haskell.TH as TH
 import qualified Language.Haskell.TH.Quote as TH
 import qualified Language.Haskell.TH.Syntax as TH
-import           System.IO.Unsafe (unsafePerformIO)
+import           System.IO.Unsafe (unsafePerformIO, unsafeDupablePerformIO)
 import qualified Text.Parsec as Parsec
 import qualified Text.Parsec.Pos as Parsec
 import qualified Text.Parser.Char as Parser
@@ -659,7 +659,7 @@ genericQuote purity build = quoteCode $ \rawStr -> do
     ioCall <- buildFunCall ctx (build here hsFunType cType cParams' cExp) (map snd hsParams) []
     -- If the user requested a pure function, make it so.
     case purity of
-      Pure -> [| unsafePerformIO $(return ioCall) |]
+      Pure -> [| unsafeDupablePerformIO $(return ioCall) |]
       IO -> return ioCall
   where
     buildFunCall :: Context -> TH.ExpQ -> [TH.Exp] -> [TH.Name] -> TH.ExpQ

--- a/inline-c/src/Language/C/Inline/Internal.hs
+++ b/inline-c/src/Language/C/Inline/Internal.hs
@@ -659,6 +659,7 @@ genericQuote purity build = quoteCode $ \rawStr -> do
     ioCall <- buildFunCall ctx (build here hsFunType cType cParams' cExp) (map snd hsParams) []
     -- If the user requested a pure function, make it so.
     case purity of
+      -- Using unsafeDupablePerformIO to increase performance of pure calls, see <https://github.com/fpco/inline-c/issues/115>
       Pure -> [| unsafeDupablePerformIO $(return ioCall) |]
       IO -> return ioCall
   where

--- a/inline-c/src/Language/C/Inline/Unsafe.hs
+++ b/inline-c/src/Language/C/Inline/Unsafe.hs
@@ -37,10 +37,16 @@ exp = genericQuote IO $ inlineExp TH.Unsafe
 
 -- | Variant of 'exp', for use with expressions known to have no side effects.
 --
--- BEWARE: use this function with caution, only when you know what you are
+-- __BEWARE__: Use this function with caution, only when you know what you are
 -- doing. If an expression does in fact have side-effects, then indiscriminate
 -- use of 'pure' may endanger referential transparency, and in principle even
--- type safety.
+-- type safety. Also note that the function may run more than once and that it
+-- may run in parallel with itself, given that
+-- 'System.IO.Unsafe.unsafeDupablePerformIO' is used to call the provided C
+-- code [to ensure good performance using the threaded
+-- runtime](https://github.com/fpco/inline-c/issues/115).  Please refer to the
+-- documentation for 'System.IO.Unsafe.unsafeDupablePerformIO' for more
+-- details.
 pure :: TH.QuasiQuoter
 pure = genericQuote Pure $ inlineExp TH.Unsafe
 


### PR DESCRIPTION
Changing from unsafePerformIO to unsafeDupablePerformIO removes the thread safety of pure functions calls, which means that expensive CPU core memory synchronization is not performed. This means that pure functions may be called more than once if called at the same time from multiple threads. This change is safe as long as the documentation is followed, since the documentation asserts that called functions are not allowed to have side effects.

This fixes overhead reported in #115.