### PR TITLE
Fix spurious build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,9 @@ before_install:
 - |
   if [ `uname` = "Darwin" ]
   then
-    travis_retry curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+    travis_retry sh -c "curl --insecure -L https://get.haskellstack.org/stable/osx-x86_64.tar.gz | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin"
   else
-    travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+    travis_retry sh -c "curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'"
   fi
 
 # This line does all of the work: installs GHC if necessary, build the library,

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,9 @@ before_install:
 # This line does all of the work: installs GHC if necessary, build the library,
 # executables, and test suites, and runs the test suites. --no-terminal works
 # around some quirks in Travis's terminal implementation.
-script: stack --no-terminal --install-ghc test --haddock $ARGS
+# -j1: work around /tmp/stack-ce322b87c3e4fa73/test-ghc-env: openBinaryFile: resource busy (file is locked)
+#      as suggested by ulidtko here https://github.com/commercialhaskell/stack/issues/5024#issuecomment-690063488
+script: stack --no-terminal --install-ghc test -j1 --haddock $ARGS
 
 # Caching so the next build will be fast too.
 cache:

--- a/inline-c/test/Language/C/Types/ParseSpec.hs
+++ b/inline-c/test/Language/C/Types/ParseSpec.hs
@@ -11,6 +11,7 @@ import           Control.Applicative
 import           Control.Monad.Trans.Class (lift)
 import           Data.Hashable (Hashable)
 import qualified Test.Hspec as Hspec
+import qualified Test.Hspec.QuickCheck
 import qualified Test.QuickCheck as QC
 import           Text.Parser.Char
 import           Text.Parser.Combinators
@@ -29,7 +30,10 @@ import           Language.C.Inline.HaskellIdentifier
 import Prelude -- Fix for 7.10 unused warnings.
 
 spec :: Hspec.SpecWith ()
-spec = do
+-- modifyMaxDiscardRatio:
+--    'isGoodType' and 'isGoodHaskellIdentifierType' usually make it within the
+--    discard ratio of 10, but we increase the ratio to avoid spurious build failures
+spec = Test.Hspec.QuickCheck.modifyMaxDiscardRatio (const 20) $ do
   Hspec.it "parses everything which is pretty-printable (C)" $ do
 #if MIN_VERSION_QuickCheck(2,9,0)
     QC.property $ QC.again $ do -- Work around <https://github.com/nick8325/quickcheck/issues/113>


### PR DESCRIPTION
I've encountered quickcheck giving in the tests. I've had a look at the cause but didn't find a good way to improve example generation. It's a good approach because apparently this isn't encountered often.
This change doubles the discard ratio, which is still good and fixes test case generation. IIUC this shift the cut-off on a bell curve to a point where the probability of failure is extremely low.

<details><summary>log section</summary>

```
Failures:
  test/Language/C/Types/ParseSpec.hs:33:3:
  1) Language.C.Types.Parse parses everything which is pretty-printable (C)
       Gave up after 94 tests; 1000 discarded!
  To rerun use: --match "/Language.C.Types.Parse/parses everything which is pretty-printable (C)/"
  test/Language/C/Types/ParseSpec.hs:44:3:
  2) Language.C.Types.Parse parses everything which is pretty-printable (Haskell)
       Gave up after 94 tests; 1000 discarded!
  To rerun use: --match "/Language.C.Types.Parse/parses everything which is pretty-printable (Haskell)/"
Randomized with seed 1695730547
```

</details>

Happy building!