### PR TITLE
llvm 7.1 / unhack cc-options

### DIFF
--- a/inline-c-cpp/cxx-src/HaskellStablePtr.cxx
+++ b/inline-c-cpp/cxx-src/HaskellStablePtr.cxx
@@ -1,6 +1,5 @@
 
 #include "HaskellStablePtr.hxx"
-#include "HsFFI.h"
 
 HaskellStablePtr::~HaskellStablePtr() {
   if (stablePtr != STABLE_PTR_NULL) {

--- a/inline-c-cpp/inline-c-cpp.cabal
+++ b/inline-c-cpp/inline-c-cpp.cabal
@@ -1,3 +1,4 @@
+cabal-version:       2.2
 name:                inline-c-cpp
 version:             0.4.0.2
 synopsis:            Lets you embed C++ code into Haskell.
@@ -11,7 +12,6 @@ copyright:           (c) 2015-2016 FP Complete Corporation, (c) 2017-2019 France
 category:            FFI
 tested-with:         GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.2
 build-type:          Simple
-cabal-version:       >=1.10
 extra-source-files:  test/*.h
 
 source-repository head
@@ -32,16 +32,19 @@ library
                      , containers
   hs-source-dirs:      src
   default-language:    Haskell2010
-  ghc-options:         -Wall -optc-xc++ -optc-std=c++11
+  ghc-options:         -Wall
   include-dirs:        include
   install-includes:    HaskellException.hxx HaskellStablePtr.hxx
   extra-libraries:     stdc++
-  c-sources:           cxx-src/HaskellException.cxx cxx-src/HaskellStablePtr.cxx
-  cc-options:          -Wall -std=c++11
+  cxx-sources:         cxx-src/HaskellException.cxx cxx-src/HaskellStablePtr.cxx
+  -- cxx-options is for .cxx _file_ compilation whereas -optcxx is
+  -- for TemplateHaskell, so we duplicate the options
+  cxx-options:         -Wall -std=c++11
+  ghc-options:         -optcxx=-Wall
+                       -optcxx=-std=c++11
   if os(darwin)
     -- avoid https://gitlab.haskell.org/ghc/ghc/issues/11829
     ld-options:        -Wl,-keep_dwarf_unwind
-    ghc-options:       -pgmc=clang++
 
 test-suite tests
   type:                exitcode-stdio-1.0
@@ -57,11 +60,12 @@ test-suite tests
                      , template-haskell
                      , vector
   default-language:    Haskell2010
-  ghc-options:
-    -optc-std=c++11
-  if os(darwin)
-    ghc-options: -pgmc=clang++
+  -- cxx-options is for .cxx _file_ compilation whereas -optcxx is
+  -- for TemplateHaskell, so we duplicate the options
+  cxx-options:         -Wall -Werror -std=c++11
+  ghc-options:         -optcxx=-Wall
+                       -optcxx=-Werror
+                       -optcxx=-std=c++11
   extra-libraries:     stdc++
-  cc-options:          -Wall -Werror -optc-xc++ -std=c++11
   if os(darwin)
     ld-options: -Wl,-keep_dwarf_unwind

--- a/inline-c-cpp/inline-c-cpp.cabal
+++ b/inline-c-cpp/inline-c-cpp.cabal
@@ -66,6 +66,8 @@ test-suite tests
   ghc-options:         -optcxx=-Wall
                        -optcxx=-Werror
                        -optcxx=-std=c++11
+                       -- Test parameter propagation:
+                       -optcxx=-DINLINE_CPP_TEST_MACRO=1
   extra-libraries:     stdc++
   if os(darwin)
     ld-options: -Wl,-keep_dwarf_unwind

--- a/inline-c-cpp/test/tests.hs
+++ b/inline-c-cpp/test/tests.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -62,6 +61,10 @@ main = Hspec.hspec $ do
     Hspec.it "Hello World" $ do
       let x = 3
       [C.block| void {
+// Sanity check for propagation of c++ compiler options through Cabal and ghc
+#ifndef INLINE_CPP_TEST_MACRO
+#error "INLINE_CPP_TEST_MACRO wasn't defined."
+#endif
           std::cout << "Hello, world!" << $(int x) << std::endl;
         } |]
 


### PR DESCRIPTION
LLVM 7.1 refuses to build master because of the hacky way we were invoking the "c++ compiler". That wasn't sustainable. Luckily Cabal >= 2.2 allows us to solve it properly.

The commits for the redundant include and the `-D` sanity check aren't strictly necessary but good to have.

Update, instead a change to LLVM 7.1, the error was triggered by `Block.h` in GHC 8.10.2. Newer releases have a [correction](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/2556) for this specific file, but are still prone to this mistake.