### PR TITLE
Fix issue of exception more lax than base version when building in macOS

### DIFF
--- a/inline-c-cpp/cxx-src/HaskellException.cxx
+++ b/inline-c-cpp/cxx-src/HaskellException.cxx
@@ -28,7 +28,16 @@ HaskellException::HaskellException(const HaskellException &other)
 {
 }
 
+#ifdef	__APPLE__
+HaskellException::~HaskellException() _NOEXCEPT
+{
+  haskellExceptionStablePtr.reset();
+}
+
+const char* HaskellException::what() const _NOEXCEPT {
+#else
 const char* HaskellException::what() const noexcept {
+#endif
   return displayExceptionValue.c_str();
 }
 

--- a/inline-c-cpp/include/HaskellException.hxx
+++ b/inline-c-cpp/include/HaskellException.hxx
@@ -16,14 +16,23 @@
    not know in advance where and how often the exception will be copied, or when
    it is released.
  */
+#ifdef	__APPLE__
 class HaskellException : public std::exception {
+#else
+class HaskellException : public std::exception {
+#endif
 public:
   std::shared_ptr<HaskellStablePtr> haskellExceptionStablePtr;
   std::string displayExceptionValue;
 
   HaskellException(std::string displayExceptionValue, void *haskellExceptionStablePtr);
   HaskellException(const HaskellException &);
+#ifdef	__APPLE__
+  virtual const char* what() const _NOEXCEPT override;
+  virtual ~HaskellException() _NOEXCEPT;
+#else
   virtual const char* what() const noexcept override;
+#endif
 
 };
 


### PR DESCRIPTION
The detail error information is:
exception specification of overriding function is more lax than base version.

The outputting  errors of cabal install inline-c-cpp is in bellow file.
[build-inline-c-cpp-errors.txt](https://github.com/fpco/inline-c/files/5901233/build-inline-c-cpp-errors.txt)
