### PR TITLE
Add `-fcompact-unwind` for darwin exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,16 @@ addons:
 matrix:
   include:
    - env: ARGS="--flag inline-c:gsl-example --flag inline-c-cpp:std-vector-example"
-   - env: ARGS="--stack-yaml stack-nightly-2021-01-01.yaml --flag inline-c:gsl-example --flag inline-c-cpp:std-vector-example"
+   - env: ARGS="--stack-yaml stack-lts-18.28.yaml --flag inline-c:gsl-example --flag inline-c-cpp:std-vector-example"
+   - env: ARGS="--stack-yaml stack-lts-16.32.yaml --flag inline-c:gsl-example --flag inline-c-cpp:std-vector-example"
    - env: ARGS="--stack-yaml stack-lts-14.27.yaml --flag inline-c:gsl-example --flag inline-c-cpp:std-vector-example"
    - env: ARGS="--stack-yaml stack-lts-12.26.yaml --flag inline-c:gsl-example --flag inline-c-cpp:std-vector-example"
 
    - env: ARGS="--flag inline-c-cpp:std-vector-example"
      os: osx
-   - env: ARGS="--stack-yaml stack-nightly-2021-01-01.yaml --flag inline-c-cpp:std-vector-example"
+   - env: ARGS="--stack-yaml stack-lts-18.28.yaml --flag inline-c-cpp:std-vector-example"
+     os: osx
+   - env: ARGS="--stack-yaml stack-lts-16.32.yaml --flag inline-c-cpp:std-vector-example"
      os: osx
    - env: ARGS="--stack-yaml stack-lts-14.27.yaml --flag inline-c-cpp:std-vector-example"
      os: osx

--- a/inline-c-cpp/inline-c-cpp.cabal
+++ b/inline-c-cpp/inline-c-cpp.cabal
@@ -10,7 +10,7 @@ author:              Francesco Mazzoli
 maintainer:          f@mazzo.li
 copyright:           (c) 2015-2016 FP Complete Corporation, (c) 2017-2019 Francesco Mazzoli
 category:            FFI
-tested-with:         GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.2
+tested-with:         GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.2, GHC == 9.2.2
 build-type:          Simple
 extra-source-files:  test/*.h
 
@@ -40,8 +40,14 @@ common cxx-opts
   extra-libraries: stdc++
 
   if os(darwin)
-    -- avoid https://gitlab.haskell.org/ghc/ghc/issues/11829
+    -- Old fix for https://gitlab.haskell.org/ghc/ghc/issues/11829
+    -- Doesn't always work. Not sufficient for aarch64-darwin
     ld-options:  -Wl,-keep_dwarf_unwind
+    -- Same issue, new fix https://gitlab.haskell.org/ghc/ghc/-/merge_requests/7247
+    -- Probably will be redundant in >=9.4 https://gitlab.haskell.org/ghc/ghc/-/merge_requests/7423
+    if impl(ghc >= 9.2.2)
+      ghc-options:
+        -fcompact-unwind
 
   if impl(ghc >= 8.10)
     ghc-options:

--- a/stack-lts-12.26.yaml
+++ b/stack-lts-12.26.yaml
@@ -1,3 +1,4 @@
+# ghc 8.4.4
 resolver: lts-12.26
 packages:
 - inline-c

--- a/stack-lts-14.27.yaml
+++ b/stack-lts-14.27.yaml
@@ -1,3 +1,4 @@
+# ghc 8.6.5
 resolver: lts-14.27
 packages:
 - inline-c

--- a/stack-lts-16.32.yaml
+++ b/stack-lts-16.32.yaml
@@ -1,9 +1,10 @@
-resolver: nightly-2021-01-01
+# ghc 8.8.4
+resolver: lts-16.32
 packages:
 - inline-c
 - inline-c-cpp
 - sample-cabal-project
 extra-deps:
-- cairo-0.13.8.1@sha256:1938aaeb5d3504678d995774dfe870f6b66cbd43d336b692fa8779b23b2b67a9,4075
 - Chart-cairo-1.9.3@sha256:f484a7194ca08ed67f02aa626e2f8f4d1a9b50624e0d50e3ced62958f7481cca,925
+- cairo-0.13.8.0@sha256:9b64a376ebaa4f153bba5866a32291fd4bed48147009cce9158ce6533928eba8,4075
 - gtk2hs-buildtools-0.13.8.0@sha256:132f38155fc677430a47ea750918973161c876fb6f281d342ac2f07eb99229ce,5238

--- a/stack-lts-18.28.yaml
+++ b/stack-lts-18.28.yaml
@@ -1,5 +1,5 @@
-# ghc 9.2.2
-resolver: nightly-2022-04-01
+# ghc 8.10.7
+resolver: lts-18.28
 packages:
 - inline-c
 - inline-c-cpp


### PR DESCRIPTION
Make exceptions work on darwin. Closes #127, noting that the fix requires a flag to be set on all executables produced by GHC 9.2.2+, but GHC 9.4 will enable it by default (probably, not merged yet, but this change was requested by upstream: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/7739)

See also https://gitlab.haskell.org/ghc/ghc/issues/11829

This also updates the CI config. I've skipped GHC 9.0 because it don't think the ffi situation has changed in that release. Such changes would also likely be in 9.2 so I don't think it's worth the time.
