### PR TITLE
Fix exception nulls

### DIFF
--- a/inline-c-cpp/cxx-src/HaskellException.cxx
+++ b/inline-c-cpp/cxx-src/HaskellException.cxx
@@ -52,6 +52,10 @@ const char* HaskellException::what() const noexcept {
     - a mangled string if demangling fails,
     - "<unknown exception>" if exception type info is not available,
     - "<no exception>" if no current exception is found.
+
+   The responsibility for freeing the returned string falls on the caller,
+   such as handleForeignCatch, which passes the responsibility on to ByteString
+
  */
 #if defined(__GNUC__) || defined(__clang__)
 const char* currentExceptionTypeName()
@@ -73,6 +77,12 @@ const char* currentExceptionTypeName()
 }
 #endif
 
+/* Set the message and type strings.
+
+   The responsibility for freeing the returned string falls on the caller,
+   such as handleForeignCatch, which passes the responsibility on to a
+   ByteString.
+ */
 void setMessageOfStdException(const std::exception &e, const char** msgStrPtr, const char **typStrPtr){
   *msgStrPtr = strdup(e.what());
   setCppExceptionType(typStrPtr);

--- a/inline-c-cpp/include/HaskellException.hxx
+++ b/inline-c-cpp/include/HaskellException.hxx
@@ -36,5 +36,5 @@ public:
 
 };
 
-void setMessageOfStdException(const std::exception &e, char** msgStrPtr, char **typeStrPtr);
-void setCppExceptionType(char** typeStrPtr);
+void setMessageOfStdException(const std::exception &e, const char** msgStrPtr, const char **typeStrPtr);
+void setCppExceptionType(const char** typeStrPtr);

--- a/inline-c-cpp/src/Language/C/Inline/Cpp/Exception.hs
+++ b/inline-c-cpp/src/Language/C/Inline/Cpp/Exception.hs
@@ -199,8 +199,8 @@ tryBlockQuoteExp blockStr = do
   let inlineCStr = unlines
         [ ty ++ " {"
         , "  int* __inline_c_cpp_exception_type__ = $(int* " ++ nameBase typePtrVarName ++ ");"
-        , "  char** __inline_c_cpp_error_message__ = $(char** " ++ nameBase msgPtrVarName ++ ");"
-        , "  char** __inline_c_cpp_error_typ__ = $(char** " ++ nameBase typeStrPtrVarName ++ ");"
+        , "  const char** __inline_c_cpp_error_message__ = $(const char** " ++ nameBase msgPtrVarName ++ ");"
+        , "  const char** __inline_c_cpp_error_typ__ = $(const char** " ++ nameBase typeStrPtrVarName ++ ");"
         , "  HaskellException** __inline_c_cpp_haskellexception__ = (HaskellException**)($(void ** " ++ nameBase haskellExPtrVarName ++ "));"
         , "  std::exception_ptr** __inline_c_cpp_exception_ptr__ = (std::exception_ptr**)$(std::exception_ptr** " ++ nameBase exPtrVarName ++ ");"
         , "  try {"

--- a/inline-c-cpp/src/Language/C/Inline/Cpp/Exception.hs
+++ b/inline-c-cpp/src/Language/C/Inline/Cpp/Exception.hs
@@ -60,7 +60,7 @@ type CppExceptionPtr = ForeignPtr AbstractCppExceptionPtr
 -- by itself, but safe when used correctly; similar to for example
 -- 'BS.unsafePackMallocCString'.
 unsafeFromNewCppExceptionPtr :: Ptr AbstractCppExceptionPtr -> IO CppExceptionPtr
-unsafeFromNewCppExceptionPtr p = newForeignPtr finalizeAbstractCppExceptionPtr p
+unsafeFromNewCppExceptionPtr = newForeignPtr finalizeAbstractCppExceptionPtr
 
 finalizeAbstractCppExceptionPtr :: FinalizerPtr AbstractCppExceptionPtr
 {-# NOINLINE finalizeAbstractCppExceptionPtr #-}

--- a/inline-c-cpp/src/Language/C/Inline/Cpp/Exception.hs
+++ b/inline-c-cpp/src/Language/C/Inline/Cpp/Exception.hs
@@ -52,6 +52,13 @@ instance Exception CppException where
 
 type CppExceptionPtr = ForeignPtr AbstractCppExceptionPtr
 
+-- | This converts a plain pointer to a managed object.
+--
+-- The pointer must have been created with @new@. The returned 'CppExceptionPtr'
+-- will @delete@ it when it is garbage collected, so you must not @delete@ it
+-- on your own. This function is called "unsafe" because it is not memory safe
+-- by itself, but safe when used correctly; similar to for example
+-- 'BS.unsafePackMallocCString'.
 unsafeFromNewCppExceptionPtr :: Ptr AbstractCppExceptionPtr -> IO CppExceptionPtr
 unsafeFromNewCppExceptionPtr p = newForeignPtr finalizeAbstractCppExceptionPtr p
 
@@ -102,8 +109,16 @@ handleForeignCatch cont =
         ExTypeNoException -> return (Right res)
         ExTypeStdException -> do
           ex <- unsafeFromNewCppExceptionPtr =<< peek exPtr
+
+          -- BS.unsafePackMallocCString: safe because setMessageOfStdException
+          -- (invoked via tryBlockQuoteExp) sets msgCStringPtr to a newly
+          -- malloced string.
           errMsg <- BS.unsafePackMallocCString =<< peek msgCStringPtr
+
+          -- BS.unsafePackMallocCString: safe because currentExceptionTypeName
+          -- returns a newly malloced string
           mbExcType <- maybePeek BS.unsafePackMallocCString =<< peek typCStringPtr
+
           return (Left (CppStdException ex errMsg mbExcType))
         ExTypeHaskellException -> do
           haskellExPtr <- peek haskellExPtrPtr
@@ -117,7 +132,11 @@ handleForeignCatch cont =
           return (Left (CppHaskellException someExc))
         ExTypeOtherException -> do
           ex <- unsafeFromNewCppExceptionPtr =<< peek exPtr
+
+          -- BS.unsafePackMallocCString: safe because currentExceptionTypeName
+          -- returns a newly malloced string
           mbExcType <- maybePeek BS.unsafePackMallocCString =<< peek typCStringPtr
+
           return (Left (CppNonStdException ex mbExcType)) :: IO (Either CppException a)
         _ -> error "Unexpected C++ exception type."
 

--- a/inline-c-cpp/test/tests.hs
+++ b/inline-c-cpp/test/tests.hs
@@ -120,6 +120,13 @@ main = Hspec.hspec $ do
 
       result `shouldBeCppOtherException` (Just "unsigned int")
 
+    Hspec.it "non-exceptions are caught (void *)" $ do
+      result <- try [C.catchBlock|
+        throw (void *)0xDEADBEEF;
+        |]
+
+      result `shouldBeCppOtherException` (Just "void*")
+
     Hspec.it "non-exceptions are caught (std::string)" $ do
       result <- try [C.catchBlock|
         throw std::string("FOOBAR");


### PR DESCRIPTION
- `currentExceptionTypeName` has crashed in what appears to be `abi::__cxa_current_exception_type()->` ( https://github.com/hercules-ci/hercules-ci-agent/issues/417). This fixes at least the crash part. (It's still not pretty)

- Some other calls have the potential to crash similarly; also fixed.

- Add a few `const` so we don't have to `strdup` for no good reason. Should be uninteresting. (I tried - lazily - to keep working with `char *` but the demangle function did not like that.)