### PR TITLE
Don't link to libstdc++ on darwin

### DIFF
--- a/inline-c-cpp/inline-c-cpp.cabal
+++ b/inline-c-cpp/inline-c-cpp.cabal
@@ -37,9 +37,12 @@ common cxx-opts
     -- version configured there.
     -std=c++11
     -Wall
-  extra-libraries: stdc++
+
+  if os(linux)
+    extra-libraries: stdc++
 
   if os(darwin)
+    extra-libraries: c++
     -- avoid https://gitlab.haskell.org/ghc/ghc/issues/11829
     ld-options:  -Wl,-keep_dwarf_unwind
 

--- a/inline-c-cpp/inline-c-cpp.cabal
+++ b/inline-c-cpp/inline-c-cpp.cabal
@@ -38,10 +38,12 @@ common cxx-opts
     -std=c++11
     -Wall
 
-  if os(linux)
+  -- Linking to the C++ standard library
+  if impl(ghc >= 9.4)
+    build-depends: system-cxx-std-lib == 1.0
+  elif os(linux)
     extra-libraries: stdc++
-
-  if os(darwin)
+  elif os(darwin)
     extra-libraries: c++
     -- avoid https://gitlab.haskell.org/ghc/ghc/issues/11829
     ld-options:  -Wl,-keep_dwarf_unwind


### PR DESCRIPTION
I believe that on OS X, one is expected to use libc++ instead of libstdc++ as the C++ standard library implementation. 