### PR TITLE
Switch to use prettyprinter

### DIFF
--- a/inline-c/inline-c.cabal
+++ b/inline-c/inline-c.cabal
@@ -63,6 +63,7 @@ test-suite tests
                      , inline-c
                      , parsers
                      , QuickCheck
+                     , prettyprinter
                      , raw-strings-qq
                      , regex-posix
                      , template-haskell

--- a/inline-c/inline-c.cabal
+++ b/inline-c/inline-c.cabal
@@ -33,7 +33,7 @@ library
   other-modules:       Language.C.Inline.FunPtr
   ghc-options:         -Wall
   build-depends:       base >=4.7 && <5
-                     , ansi-wl-pprint >= 0.6.8 && < 1.0.0
+                     , prettyprinter >=1.7
                      , bytestring
                      , containers
                      , hashable
@@ -57,7 +57,6 @@ test-suite tests
                      , Language.C.Types.ParseSpec
   build-depends:       base >=4 && <5
                      , QuickCheck
-                     , ansi-wl-pprint
                      , containers
                      , hashable
                      , hspec >= 2

--- a/inline-c/src/Language/C/Inline/HaskellIdentifier.hs
+++ b/inline-c/src/Language/C/Inline/HaskellIdentifier.hs
@@ -30,7 +30,7 @@ import           Text.Parser.Char (upper, lower, digit, char)
 import           Text.Parser.Combinators (many, eof, try, unexpected, (<?>))
 import           Text.Parser.Token (IdentifierStyle(..), highlight, TokenParsing)
 import qualified Text.Parser.Token.Highlight as Highlight
-import qualified Text.PrettyPrint.ANSI.Leijen as PP
+import qualified Prettyprinter as PP
 
 import qualified Language.C.Types.Parse as C
 
@@ -49,7 +49,7 @@ instance IsString HaskellIdentifier where
       Right x -> x
 
 instance PP.Pretty HaskellIdentifier where
-  pretty = PP.text . unHaskellIdentifier
+  pretty = fromString . unHaskellIdentifier
 
 haskellIdentifierFromString :: Bool -> String -> Either String HaskellIdentifier
 haskellIdentifierFromString useCpp s =

--- a/inline-c/src/Language/C/Types/Parse.hs
+++ b/inline-c/src/Language/C/Types/Parse.hs
@@ -102,8 +102,8 @@ import           Text.Parser.Combinators
 import           Text.Parser.LookAhead
 import           Text.Parser.Token
 import qualified Text.Parser.Token.Highlight as Highlight
-import           Text.PrettyPrint.ANSI.Leijen (Pretty(..), (<+>), Doc, hsep)
-import qualified Text.PrettyPrint.ANSI.Leijen as PP
+import           Prettyprinter (Pretty(..), (<+>), Doc, hsep)
+import qualified Prettyprinter as PP
 
 #if __GLASGOW_HASKELL__ < 710
 import           Data.Foldable (Foldable)
@@ -531,7 +531,7 @@ direct_abstract_declarator = do
 -- Pretty printing
 
 instance Pretty CIdentifier where
-  pretty = PP.text . unCIdentifier
+  pretty = fromString . unCIdentifier
 
 instance Pretty DeclarationSpecifier where
   pretty dspec = case dspec of
@@ -586,7 +586,7 @@ instance Pretty i => Pretty (Declarator i) where
     [] -> pretty ddecltor
     _:_ -> prettyPointers ptrs <+> pretty ddecltor
 
-prettyPointers :: [Pointer] -> Doc
+prettyPointers :: [Pointer] -> Doc ann
 prettyPointers [] = ""
 prettyPointers (x : xs) = pretty x <> prettyPointers xs
 
@@ -604,7 +604,7 @@ instance Pretty i => Pretty (ArrayOrProto i) where
     Array x -> "[" <> pretty x <> "]"
     Proto x -> "(" <> prettyParams x <> ")"
 
-prettyParams :: (Pretty a) => [a] -> Doc
+prettyParams :: (Pretty a) => [a] -> Doc ann
 prettyParams xs = case xs of
   [] -> ""
   [x] -> pretty x

--- a/inline-c/test/Language/C/Types/ParseSpec.hs
+++ b/inline-c/test/Language/C/Types/ParseSpec.hs
@@ -15,7 +15,8 @@ import qualified Test.Hspec.QuickCheck
 import qualified Test.QuickCheck as QC
 import           Text.Parser.Char
 import           Text.Parser.Combinators
-import qualified Text.PrettyPrint.ANSI.Leijen as PP
+import qualified Prettyprinter as PP
+import qualified Prettyprinter.Render.String as PP
 import           Data.Typeable (Typeable)
 import qualified Data.HashSet as HashSet
 import           Data.List (intercalate)
@@ -43,7 +44,7 @@ spec = Test.Hspec.QuickCheck.modifyMaxDiscardRatio (const 20) $ do
       ParameterDeclarationWithTypeNames typeNames ty <-
         arbitraryParameterDeclarationWithTypeNames unCIdentifier
       return $ isGoodType ty QC.==>
-        let ty' = assertParse (cCParserContext True typeNames) parameter_declaration (prettyOneLine ty)
+        let ty' = assertParse (cCParserContext True typeNames) parameter_declaration (prettyOneLine (PP.pretty ty))
         in Types.untangleParameterDeclaration ty == Types.untangleParameterDeclaration ty'
   Hspec.it "parses everything which is pretty-printable (Haskell)" $ do
 #if MIN_VERSION_QuickCheck(2,9,0)
@@ -54,7 +55,7 @@ spec = Test.Hspec.QuickCheck.modifyMaxDiscardRatio (const 20) $ do
       ParameterDeclarationWithTypeNames typeNames ty <-
         arbitraryParameterDeclarationWithTypeNames unHaskellIdentifier
       return $ isGoodHaskellIdentifierType typeNames ty QC.==>
-        let ty' = assertParse (haskellCParserContext True typeNames) parameter_declaration (prettyOneLine ty)
+        let ty' = assertParse (haskellCParserContext True typeNames) parameter_declaration (prettyOneLine (PP.pretty ty))
         in Types.untangleParameterDeclaration ty == Types.untangleParameterDeclaration ty'
 
 ------------------------------------------------------------------------
@@ -68,8 +69,8 @@ assertParse ctx p s =
     Left err -> error $ "Parse error (assertParse): " ++ show err ++ " parsed string " ++ show s ++ " with type names " ++ show (cpcTypeNames ctx)
     Right x -> x
 
-prettyOneLine :: PP.Pretty a => a -> String
-prettyOneLine x = PP.displayS (PP.renderCompact (PP.pretty x)) ""
+prettyOneLine :: PP.Doc ann -> String
+prettyOneLine x = PP.renderString $ PP.layoutCompact x
 
 isGoodType :: ParameterDeclaration i -> Bool
 isGoodType ty =


### PR DESCRIPTION
`ansi-wl-pprint` is deprecated in favour of `prettyprinter`.

Why do I care about this? The answer is somewhat annoying:
- `optparse-applicative` and `ansi-wl-pprint` interoperate nicely unless you get a specific combination of versions, namely an old `ansi-wl-pprint` (before it switched to `prettyprinter`) and a new `optparse-applicative` (after it switched to `prettyprinter`). This can manifest for example in [`turtle`](https://github.com/Gabriella439/turtle/pull/446#issuecomment-1660656912)
- `inline-c` is what is causing me to pull in an old `ansi-wl-pprint`, so I figured I could also just try and fix that :)