### PR TITLE
Add -fcompact-unwind for darwin exceptions

### DIFF
--- a/inline-c-cpp/inline-c-cpp.cabal
+++ b/inline-c-cpp/inline-c-cpp.cabal
@@ -10,7 +10,7 @@ author:              Francesco Mazzoli
 maintainer:          f@mazzo.li
 copyright:           (c) 2015-2016 FP Complete Corporation, (c) 2017-2019 Francesco Mazzoli
 category:            FFI
-tested-with:         GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.2
+tested-with:         GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.2, GHC == 9.2.2
 build-type:          Simple
 extra-source-files:  test/*.h
 
@@ -47,6 +47,11 @@ common cxx-opts
     extra-libraries: c++
     -- avoid https://gitlab.haskell.org/ghc/ghc/issues/11829
     ld-options:  -Wl,-keep_dwarf_unwind
+    -- Same issue, new fix https://gitlab.haskell.org/ghc/ghc/-/merge_requests/7247
+    -- Probably will be redundant in >=9.4 https://gitlab.haskell.org/ghc/ghc/-/merge_requests/7423
+    if impl(ghc >= 9.2.2 && < 9.4)
+      ghc-options:
+        -fcompact-unwind
 
   if impl(ghc >= 8.10)
     ghc-options:


### PR DESCRIPTION
This is almost the same as https://github.com/fpco/inline-c/pull/131. 
Some modifications to fix conflicts are included.
This PR is tested on my apple silicon.
