### PR TITLE
Track included files via TH's addDependentFile

### DIFF
--- a/inline-c/inline-c.cabal
+++ b/inline-c/inline-c.cabal
@@ -44,6 +44,8 @@ library
                      , transformers >= 0.1.3.0
                      , unordered-containers
                      , vector
+                     , filepath
+                     , directory
   hs-source-dirs:      src
   default-language:    Haskell2010
 


### PR DESCRIPTION
Closes #152 

---
Previously, files included via `C.include` would not be tracked by GHC, so changes made to say `test.h` would not recompile a `Foo.hs` with `C.include "test.h"`. If working with cabal, tracked files *must* be placed in cabal's top level `extra-source-files` stanza in order for this to be useful, more context given in the relevant issue.

#### Possible outstanding issues:

The solution in this PR only applies to files that are referenced relative to the current file. That is, if one were to have this setup:
```
package
 ├──src
 │   └──Main.hs
 ├──cbits
 │   └──test.h
 └──test.cabal
```
With a cabal file containing:
`ghc-options: -threaded -I./cbits`

While the usage of `C.include "test.h"` would still work, it would no longer be tracked. I can't think of any solution to this other than trying to access the GHC flags from within TH, which I have seen done, but seemed very hacky, using `unsafeCoerce` to get a `TcM` from a `Q`.

Perhaps there is another principle approach that would make use of how the C preprocessor itself looks for files. As it stands, this PR also only applies to includes of the form `"..."` ignoring `<...>`.
